### PR TITLE
Fix/723-font weight changes in people directory

### DIFF
--- a/src/community/common/components/molecules/AvatarSearch/AvatarSearch.tsx
+++ b/src/community/common/components/molecules/AvatarSearch/AvatarSearch.tsx
@@ -88,11 +88,9 @@ const AvatarSearch = ({
         }}
       >
         <Typography
-          variant="h5"
+          variant="placeholder"
           gutterBottom
           sx={{
-            fontWeight: "500",
-            fontSize: "1rem",
             color:
               (errors ?? "")
                 ? theme.palette.error.contrastText

--- a/src/community/common/components/molecules/DropdownAutocomplete/DropdownAutocomplete.tsx
+++ b/src/community/common/components/molecules/DropdownAutocomplete/DropdownAutocomplete.tsx
@@ -94,8 +94,7 @@ const DropdownAutocomplete: FC<Props> = ({
     >
       <Stack direction="row" justifyContent="space-between">
         <Typography
-          component="label"
-          variant="label"
+          variant="placeholder"
           sx={{
             color: isDisabled
               ? theme.palette.text.disabled

--- a/src/community/common/components/molecules/DropdownList/styles.ts
+++ b/src/community/common/components/molecules/DropdownList/styles.ts
@@ -11,7 +11,7 @@ export const styles = (theme: Theme) => ({
   },
 
   labelStyle: (isDisabled: boolean, error: boolean) => ({
-    fontWeight: 500,
+    fontWeight: 400,
     color: isDisabled
       ? theme.palette.text.disabled
       : error

--- a/src/community/common/components/molecules/InputDate/InputDate.tsx
+++ b/src/community/common/components/molecules/InputDate/InputDate.tsx
@@ -195,7 +195,7 @@ const InputDate: FC<Props> = ({
           component="label"
           lineHeight={1.5}
           sx={{
-            fontWeight: 500,
+            fontWeight: 400,
             color: disabled
               ? theme.palette.text.disabled
               : error

--- a/src/community/common/components/molecules/InputPhoneNumber/InputPhoneNumber.tsx
+++ b/src/community/common/components/molecules/InputPhoneNumber/InputPhoneNumber.tsx
@@ -59,8 +59,7 @@ const InputPhoneNumber: FC<Props> = ({
         }}
       >
         <Typography
-          component="label"
-          variant="label"
+          variant="placeholder"
           sx={{
             color: isDisabled
               ? theme.palette.text.disabled


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/skappHQ/skapp-fe/blob/main/CONTRIBUTING.md) file - YES/NO

## PR checklist

### Issue ID: [#723](https://github.com/SkappHQ/skapp-fe/issues/723)

### Summary

- There is a difference in some labels in add new employee flow. which some of the labels had the font weight of 500 and few 400. changed them into standard weight of 400.

### How to test

1.

### Project Checklist

Please add an `x` to mark the checkbox:

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is checked for lint issues with `npm run check-lint` and issues are fixed with `npm run lint-fix`
- [ ] No unnecessary comments left in the code
- [ ] User-displaying text is added as translations
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is created to the correct base branch
- [ ] Pull request is created with the correct branch name
- [ ] Pull request is created with a meaningful title
- [ ] Pull request is self reviewed
- [ ] Suitable pull request status labels are added (`ready-for-code-review` & `waiting-for-developer-testing`)

### Additional Information
