### PR TITLE
Fix/543: Next Button in System Permission Section and  Leave Entitlment is Not Visible When the Leave Module is Off

### DIFF
--- a/src/community/people/components/organisms/AddNewResourceFlow/AddNewResourceFlow.tsx
+++ b/src/community/people/components/organisms/AddNewResourceFlow/AddNewResourceFlow.tsx
@@ -71,7 +71,7 @@ const AddNewResourceFlow = () => {
       translateText(["entitlements"])
     ];
 
-    if (isLeaveModuleEnabled) {
+    if (!isLeaveModuleEnabled) {
       steps = steps.filter((step) => step !== translateText(["entitlements"]));
     }
 

--- a/src/community/people/components/organisms/AddNewResourceFlow/EmploymentDetailsSection/EmploymentDetailsForm.tsx
+++ b/src/community/people/components/organisms/AddNewResourceFlow/EmploymentDetailsSection/EmploymentDetailsForm.tsx
@@ -6,7 +6,6 @@ import Button from "~community/common/components/atoms/Button/Button";
 import PeopleLayout from "~community/common/components/templates/PeopleLayout/PeopleLayout";
 import { employmentDetailsFormTestId } from "~community/common/constants/testIds";
 import { ButtonStyle } from "~community/common/enums/ComponentEnums";
-import useModuleChecker from "~community/common/hooks/useModuleChecker";
 import { useTranslator } from "~community/common/hooks/useTranslator";
 import { useToast } from "~community/common/providers/ToastProvider";
 import { IconName } from "~community/common/types/IconTypes";
@@ -65,8 +64,6 @@ const EmploymentDetailsForm = ({
   const router = useRouter();
 
   const { setToastMessage } = useToast();
-
-  const { isLeaveModuleEnabled } = useModuleChecker();
 
   const { resetEmployeeData, employeeDataChanges } = usePeopleStore(
     (state) => state
@@ -168,9 +165,7 @@ const EmploymentDetailsForm = ({
         height: "auto",
         fontFamily: "Poppins, sans-serif"
       }}
-      dividerStyles={{
-        mt: "0.5rem"
-      }}
+      dividerStyles={{ mt: "0.5rem" }}
       pageHead={translateText(["head"])}
       showDivider={false}
     >
@@ -217,15 +212,13 @@ const EmploymentDetailsForm = ({
             />
             <Button
               label={
-                isUpdate || !isLeaveModuleEnabled
+                isUpdate
                   ? translateText(["saveDetails"])
                   : translateText(["next"])
               }
               buttonStyle={ButtonStyle.PRIMARY}
               endIcon={
-                isUpdate || !isLeaveModuleEnabled
-                  ? IconName.SAVE_ICON
-                  : IconName.RIGHT_ARROW_ICON
+                isUpdate ? IconName.SAVE_ICON : IconName.RIGHT_ARROW_ICON
               }
               isFullWidth={false}
               onClick={handleNext}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/skappHQ/skapp-fe/blob/main/CONTRIBUTING.md) file - YES/NO

## PR checklist

### Issue ID: [#526](https://github.com/rootcodelabs/skapp-ep/issues/526)
### Issue ID: [#543](https://github.com/rootcodelabs/skapp-ep/issues/543)


### Summary

-

### How to test

1.

### Project Checklist

Please add an `x` to mark the checkbox:

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is checked for lint issues with `npm run check-lint` and issues are fixed with `npm run lint-fix`
- [ ] No unnecessary comments left in the code
- [ ] User-displaying text is added as translations
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is created to the correct base branch
- [ ] Pull request is created with the correct branch name
- [ ] Pull request is created with a meaningful title
- [ ] Pull request is self reviewed
- [ ] Suitable pull request status labels are added (`ready-for-code-review` & `waiting-for-developer-testing`)

### Additional Information
