### PR TITLE
chore: update DropdownList component for improved accessibility and u…

### DIFF
--- a/frontend/src/community/common/components/molecules/DropdownList/DropdownList.tsx
+++ b/frontend/src/community/common/components/molecules/DropdownList/DropdownList.tsx
@@ -63,6 +63,8 @@ interface Props {
   checkSelected?: boolean;
   typographyStyles?: SxProps;
   enableTextWrapping?: boolean;
+  showSpinnerWhenNoData?: boolean;
+  noOptionsText?: string;
 }
 
 const DropdownList: FC<Props> = ({
@@ -95,7 +97,9 @@ const DropdownList: FC<Props> = ({
   checkSelected,
   ariaLabel,
   typographyStyles,
-  enableTextWrapping = false
+  enableTextWrapping = false,
+  showSpinnerWhenNoData = true,
+  noOptionsText
 }: Props) => {
   const theme: Theme = useTheme();
   const classes = styles(theme);
@@ -301,9 +305,15 @@ const DropdownList: FC<Props> = ({
               "aria-required": required
             }}
           >
-            <Box display={"flex"} justifyContent={"center"}>
-              <CircularProgress size={20} style={{ color: "black" }} />
-            </Box>
+            {showSpinnerWhenNoData ? (
+              <Box display={"flex"} justifyContent={"center"}>
+                <CircularProgress size={20} style={{ color: "black" }} />
+              </Box>
+            ) : (
+              <Typography variant="body2" sx={{ p: 1 }}>
+                {noOptionsText}
+              </Typography>
+            )}
           </Select>
         )}
       </Paper>


### PR DESCRIPTION
## PR checklist

https://rootcode.skapp.com/pm/projects/SKAPP/items/297
This pull request introduces several updates across both frontend and backend components, with a focus on enhancing tracking capabilities and improving the flexibility of the `DropdownList` component. The main changes include the integration of Meta Pixel for analytics, new customization options for dropdown lists, and updates to subproject dependencies.

**Tracking and Analytics Integration:**

* Added Meta Pixel tracking code and noscript fallback to `frontend/pages/_document.tsx` for improved analytics and user tracking. [[1]](diffhunk://#diff-67d552fc4bfdf5882704e9a1458efe2093cea318fc8a180e70c6192501e8e312R67-R83) [[2]](diffhunk://#diff-67d552fc4bfdf5882704e9a1458efe2093cea318fc8a180e70c6192501e8e312R94-R103)

**DropdownList Component Enhancements:**

* Extended the `DropdownList` component props to support custom typography styles, text wrapping, conditional spinner display, and a customizable "no options" message in `frontend/src/community/common/components/molecules/DropdownList/DropdownList.tsx`. [[1]](diffhunk://#diff-77e61a2c9b95b2500b8147163ceb616e35edc838476fb648fc3bd58f1a0f250eR64-R67) [[2]](diffhunk://#diff-77e61a2c9b95b2500b8147163ceb616e35edc838476fb648fc3bd58f1a0f250eL94-R102)
* Updated dropdown menu styling to allow text wrapping and custom width when enabled.
* Applied custom typography styles to dropdown menu items for greater UI flexibility.
* Improved handling of empty dropdown states by conditionally showing a spinner or a custom message.

**Subproject Dependency Updates:**

* Updated backend and frontend subproject commit references to point to newer versions, ensuring the latest code and features are included. (`backend/src/main/java/com/skapp/enterprise`, [[1]](diffhunk://#diff-2e279ee9340cc598df9d0310c14b38ae660a4de1b3672b1cb18b17d8df4ae39aL1-R1); `backend/src/main/resources/enterprise`, [[2]](diffhunk://#diff-eea6799d63961b97295333bd5e817449721f90758a0b79e02cd9d522f29191e2L1-R1); `frontend/pages/enterprise`, [[3]](diffhunk://#diff-8b44a4243fe79a0b145368aad2ee4c4587d898da27b57763c03808f9a30c650eL1-R1); `frontend/src/enterprise`, [[4]](diffhunk://#diff-6e111f3fda42d8e58ba1d3f9a01f9d45c640f24a3fc54d3b2b4d3228a94fa522L1-R1)

### Summary

-

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
This pull request enhances the `DropdownList` component by adding new props to improve how it handles scenarios when there are no options available. The changes focus on providing flexibility for displaying either a spinner or a custom message when the dropdown is empty.

**Dropdown UI/UX improvements:**

* Added two new props to `DropdownList`: `showSpinnerWhenNoData` (controls whether a spinner is shown when there are no options) and `noOptionsText` (customizes the text displayed when no options are available).
* Set default values for the new props: `showSpinnerWhenNoData` defaults to `true`, and `noOptionsText` can be customized by the parent component.
* Updated the dropdown rendering logic to conditionally show either a spinner or a custom message, depending on the value of `showSpinnerWhenNoData`.