### PR TITLE
fix: add pending column to PeopleTable when invitation list is open

### DIFF
--- a/frontend/src/community/common/assets/languages/english/peopleModule.json
+++ b/frontend/src/community/common/assets/languages/english/peopleModule.json
@@ -339,7 +339,8 @@
       "jobTitle": "Job Title",
       "email": "Email",
       "team": "Teams",
-      "supervisor": "Supervisors"
+      "supervisor": "Supervisors",
+      "pending":""
     },
     "bulkUploadBtnTxt": "Add all your people in one go",
     "uploadCsvModalTitle": "Add people",

--- a/frontend/src/community/people/components/molecules/PeopleTable/PeopleTable.tsx
+++ b/frontend/src/community/people/components/molecules/PeopleTable/PeopleTable.tsx
@@ -189,6 +189,16 @@ const PeopleTable: FC<Props> = ({
 
   const columns = [
     { field: "name", headerName: translateText(["tableHeaders", "name"]) },
+    ...(isPendingInvitationListOpen
+      ? [
+          {
+            field: "pending",
+            headerName: translateText(["tableHeaders", "pending"]),
+            width: "0.5%",
+            align: "left"
+          }
+        ]
+      : []),
     {
       field: "jobTitle",
       headerName: translateText(["tableHeaders", "jobTitle"])
@@ -238,8 +248,8 @@ const PeopleTable: FC<Props> = ({
                   ? "common.black"
                   : theme.palette.grey[700],
                 maxWidth: isPendingInvitationListOpen
-                  ? "13.425rem"
-                  : "18.425rem",
+                  ? "14.425rem"
+                  : "14.75rem",
                 minWidth: 0,
                 width: "fit-content",
                 "& .MuiChip-label": {
@@ -248,26 +258,23 @@ const PeopleTable: FC<Props> = ({
                 justifyContent: "flex-start"
               }}
             />
-            {isPendingInvitationListOpen && (
-              <Stack
-                sx={{
-                  flexDirection: "row",
-                  alignItems: "center",
-                  gap: 1,
-                  backgroundColor: theme.palette.amber.light,
-                  color: theme.palette.amber.dark,
-                  padding: "0.25rem",
-                  borderRadius: 10,
-                  fontSize: "0.625rem"
-                }}
-              >
-                <Icon
-                  name={IconName.CLOCK_ICON}
-                  fill={theme.palette.amber.dark}
-                />
-                {translateText(["Pending"])}
-              </Stack>
-            )}
+          </Stack>
+        ),
+        pending: isPendingInvitationListOpen && (
+          <Stack
+            sx={{
+              flexDirection: "row",
+              alignItems: "flex-start",
+              gap: 1,
+              backgroundColor: theme.palette.amber.light,
+              color: theme.palette.amber.dark,
+              padding: "0.25rem",
+              borderRadius: 10,
+              fontSize: "0.625rem"
+            }}
+          >
+            <Icon name={IconName.CLOCK_ICON} fill={theme.palette.amber.dark} />
+            {translateText(["Pending"])}
           </Stack>
         ),
         jobTitle: (


### PR DESCRIPTION
## PR checklist

https://rootcode.skapp.com/pm/projects/SKAPP/items/278
https://rootcode.skapp.com/pm/projects/SKAPP/items/279

### Summary

This pull request updates the `PeopleTable` component to support displaying pending invitations and makes related UI adjustments. The main changes include adding a new "Pending" column when viewing pending invitations, modifying the table's layout to accommodate this, and updating the language file for consistency.

**Pending Invitations Feature:**

* Added a "Pending" column to the table when `isPendingInvitationListOpen` is true, including its header and rendering logic.
* Updated the table row rendering to display a styled pending invitation indicator (clock icon and label) when appropriate. [[1]](diffhunk://#diff-e9d9e50e675ddb15a7c4e75b977064997c7ce9fec0ff332f8abccfb12b323ae3L251-R267) [[2]](diffhunk://#diff-e9d9e50e675ddb15a7c4e75b977064997c7ce9fec0ff332f8abccfb12b323ae3L264-L271)

**UI Adjustments:**

* Modified the maximum width of the name column to better fit the new layout when the pending invitation list is open.

**Localization Updates:**

* Added the "pending" key to the English language file to support the new column header.

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
