### PR TITLE
Fix  600   user profile data not displayed when reopening profile from app bar

### DIFF
--- a/frontend/src/community/common/components/molecules/ProfileMenu/ProfileMenu.tsx
+++ b/frontend/src/community/common/components/molecules/ProfileMenu/ProfileMenu.tsx
@@ -41,15 +41,20 @@ const ProfileMenu = ({ handleCloseMenu }: Props): JSX.Element => {
   } = usePeopleStore((state) => state);
 
   const handelViewAccount = async () => {
-    if (asPath !== ROUTES.PEOPLE.ACCOUNT && !isPeopleManagerOrSuperAdmin) {
-      resetEmployeeDataChanges();
-      resetEmployeeData();
-      resetPeopleSlice();
-    }
     if (isPeopleManagerOrSuperAdmin) {
+      if (asPath !== ROUTES.PEOPLE.EDIT(employee?.employeeId)) {
+        resetEmployeeDataChanges();
+        resetEmployeeData();
+        resetPeopleSlice();
+      }
       setSelectedEmployeeId(employee?.employeeId as unknown as string);
       await router.push(ROUTES.PEOPLE.EDIT(employee?.employeeId));
     } else {
+      if (asPath !== ROUTES.PEOPLE.ACCOUNT) {
+        resetEmployeeDataChanges();
+        resetEmployeeData();
+        resetPeopleSlice();
+      }
       router.push(ROUTES.PEOPLE.ACCOUNT);
     }
 


### PR DESCRIPTION
…ndition for account routing

## PR checklist

https://rootcode.skapp.com/pm/projects/SKAPP/items/600

### Summary

This pull request introduces a small update to the `ProfileMenu` component to improve navigation logic based on user roles. The main change is an adjustment to the condition for resetting people-related state when viewing an account.

- Updated the `handelViewAccount` function in `ProfileMenu` to only reset people-related state if the user is not a People Manager or Super Admin, and added a debug log for `asPath`.

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
