### PR TITLE
removed condition for integration side nav pannel

### DIFF
--- a/frontend/src/community/common/utils/getEnterpriseDrawerRoutes.ts
+++ b/frontend/src/community/common/utils/getEnterpriseDrawerRoutes.ts
@@ -45,8 +45,7 @@ const getEnterpriseDrawerRoutes = ({
         if (
           (globalLoginMethod === GlobalLoginMethod.GOOGLE &&
             organizationCalendarGoogleStatus === false) ||
-          (globalLoginMethod === GlobalLoginMethod.MICROSOFT &&
-            organizationCalendarMicrosoftStatus === false)
+          globalLoginMethod === GlobalLoginMethod.MICROSOFT
         ) {
           return null;
         }


### PR DESCRIPTION
This pull request makes a targeted change to the logic for determining enterprise drawer routes in the `getEnterpriseDrawerRoutes` utility. The main update simplifies the condition for handling Microsoft login methods.

* Logic simplification: The check for `organizationCalendarMicrosoftStatus === false` has been removed. Now, the route will return `null` for all users with the Microsoft login method, regardless of the organization's calendar status. (`frontend/src/community/common/utils/getEnterpriseDrawerRoutes.ts`)