### PR TITLE
Fix/skapp 1210 leave entitlements fails for special characters

### DIFF
--- a/frontend/src/community/leave/utils/leaveEntitlement/leaveEntitlementUtils.ts
+++ b/frontend/src/community/leave/utils/leaveEntitlement/leaveEntitlementUtils.ts
@@ -137,10 +137,7 @@ const getLeaveEntitlementsForEmployee = (
 
   const entitlements = leaveTypeNames.map((leaveType) => {
     const leaveTypeDetails = leaveTypes?.find((type) => {
-      return (
-        type?.name?.replace(/\s+/g, "").toLowerCase() ===
-        leaveType?.toLowerCase()
-      );
+      return toCamelCase(type?.name ?? "") === leaveType;
     });
 
     return {

--- a/frontend/src/community/leave/utils/leaveEntitlement/leaveEntitlementUtils.ts
+++ b/frontend/src/community/leave/utils/leaveEntitlement/leaveEntitlementUtils.ts
@@ -137,7 +137,10 @@ const getLeaveEntitlementsForEmployee = (
 
   const entitlements = leaveTypeNames.map((leaveType) => {
     const leaveTypeDetails = leaveTypes?.find((type) => {
-      return toCamelCase(type?.name ?? "") === leaveType;
+      return (
+        type?.name?.replace(/[\s\-]+/g, "").toLowerCase() ===
+        leaveType?.toLowerCase()
+      );
     });
 
     return {

--- a/frontend/src/community/leave/utils/leaveEntitlement/leaveEntitlementUtils.ts
+++ b/frontend/src/community/leave/utils/leaveEntitlement/leaveEntitlementUtils.ts
@@ -138,7 +138,7 @@ const getLeaveEntitlementsForEmployee = (
   const entitlements = leaveTypeNames.map((leaveType) => {
     const leaveTypeDetails = leaveTypes?.find((type) => {
       return (
-        type?.name?.replace(/[\s\-]+/g, "").toLowerCase() ===
+        type?.name?.replace(/[\s-]+/g, "").toLowerCase() ===
         leaveType?.toLowerCase()
       );
     });


### PR DESCRIPTION
## PR checklist

### TaskId:(https://rootcode.skapp.com/pm/projects/SKAPP/items/1210)


### Summary
Special Characters allowed are - apostrophes ('), hyphens (-), accents, and diacritics (acute ´, grave `, circumflex ^, tilde ~, cedilla ç, umlaut/diaeresis ¨, rings ˚, slashes Ø/ø, specific diacritical marks: slash ł, macron ¯).
-

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
