### PR TITLE
fix: integrate team data retrieval in AccountSectionWrapper (1703)

### DIFF
--- a/frontend/src/community/people/components/molecules/PeopleTable/PeopleTable.tsx
+++ b/frontend/src/community/people/components/molecules/PeopleTable/PeopleTable.tsx
@@ -487,7 +487,9 @@ const PeopleTable: FC<Props> = ({
 
   useEffect(() => {
     if (!isLoading && teamData)
-      setProjectTeamNames(teamData as TeamNamesType[]);
+      setProjectTeamNames(
+        teamData.map(({ teamId, teamName }) => ({ teamId, teamName }))
+      );
   }, [isLoading, teamData]);
 
   const handleRowClick = async (employee: { id: number }) => {

--- a/frontend/src/community/people/components/molecules/PeopleTable/PeopleTable.tsx
+++ b/frontend/src/community/people/components/molecules/PeopleTable/PeopleTable.tsx
@@ -487,9 +487,7 @@ const PeopleTable: FC<Props> = ({
 
   useEffect(() => {
     if (!isLoading && teamData)
-      setProjectTeamNames(
-        teamData.map(({ teamId, teamName }) => ({ teamId, teamName }))
-      );
+      setProjectTeamNames(teamData as TeamNamesType[]);
   }, [isLoading, teamData]);
 
   const handleRowClick = async (employee: { id: number }) => {

--- a/frontend/src/community/people/components/organisms/AccountSectionWrapper/AccountSectionWrapper.tsx
+++ b/frontend/src/community/people/components/organisms/AccountSectionWrapper/AccountSectionWrapper.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 
 import { useGetEmployee } from "~community/people/api/PeopleApi";
 import { useGetAllTeams } from "~community/people/api/TeamApi";
+import { TeamNamesType } from "~community/people/types/TeamTypes";
 import useFormChangeDetector from "~community/people/hooks/useFormChangeDetector";
 import { usePeopleStore } from "~community/people/store/store";
 
@@ -41,9 +42,7 @@ const AccountSectionWrapper = ({ employeeId }: Props) => {
 
   useEffect(() => {
     if (teamData) {
-      setProjectTeamNames(
-        teamData.map(({ teamId, teamName }) => ({ teamId, teamName }))
-      );
+      setProjectTeamNames(teamData as TeamNamesType[]);
     }
   }, [teamData, setProjectTeamNames]);
 

--- a/frontend/src/community/people/components/organisms/AccountSectionWrapper/AccountSectionWrapper.tsx
+++ b/frontend/src/community/people/components/organisms/AccountSectionWrapper/AccountSectionWrapper.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useRef } from "react";
 
 import { useGetEmployee } from "~community/people/api/PeopleApi";
+import { useGetAllTeams } from "~community/people/api/TeamApi";
 import useFormChangeDetector from "~community/people/hooks/useFormChangeDetector";
 import { usePeopleStore } from "~community/people/store/store";
+import { TeamNamesType } from "~community/people/types/TeamTypes";
 
 import DirectorySteppers from "../../molecules/DirectorySteppers/DirectorySteppers";
 import RouteChangeAreYouSureModal from "../../molecules/RouteChangeAreYouSureModal/RouteChangeAreYouSureModal";
@@ -15,6 +17,7 @@ interface Props {
 }
 const AccountSectionWrapper = ({ employeeId }: Props) => {
   const { data: employeeData } = useGetEmployee(employeeId);
+  const { data: teamData, isLoading: isTeamsLoading } = useGetAllTeams();
 
   const accountSectionsRef = useRef<HTMLDivElement>(null);
 
@@ -27,7 +30,8 @@ const AccountSectionWrapper = ({ employeeId }: Props) => {
     setCurrentStep,
     setIsUnsavedModalSaveButtonClicked,
     setIsUnsavedModalDiscardButtonClicked,
-    setEmployee
+    setEmployee,
+    setProjectTeamNames
   } = usePeopleStore((state) => state);
 
   useEffect(() => {
@@ -35,6 +39,12 @@ const AccountSectionWrapper = ({ employeeId }: Props) => {
       setEmployee(employeeData?.data?.results[0]);
     }
   }, [employeeData, setEmployee]);
+
+  useEffect(() => {
+    if (!isTeamsLoading && teamData) {
+      setProjectTeamNames(teamData as TeamNamesType[]);
+    }
+  }, [isTeamsLoading, teamData, setProjectTeamNames]);
 
   const { hasChanged } = useFormChangeDetector();
 

--- a/frontend/src/community/people/components/organisms/AccountSectionWrapper/AccountSectionWrapper.tsx
+++ b/frontend/src/community/people/components/organisms/AccountSectionWrapper/AccountSectionWrapper.tsx
@@ -42,7 +42,9 @@ const AccountSectionWrapper = ({ employeeId }: Props) => {
 
   useEffect(() => {
     if (!isTeamsLoading && teamData) {
-      setProjectTeamNames(teamData as TeamNamesType[]);
+      setProjectTeamNames(
+        teamData.map(({ teamId, teamName }) => ({ teamId, teamName }))
+      );
     }
   }, [isTeamsLoading, teamData, setProjectTeamNames]);
 

--- a/frontend/src/community/people/components/organisms/AccountSectionWrapper/AccountSectionWrapper.tsx
+++ b/frontend/src/community/people/components/organisms/AccountSectionWrapper/AccountSectionWrapper.tsx
@@ -16,7 +16,7 @@ interface Props {
 }
 const AccountSectionWrapper = ({ employeeId }: Props) => {
   const { data: employeeData } = useGetEmployee(employeeId);
-  const { data: teamData, isLoading: isTeamsLoading } = useGetAllTeams();
+  const { data: teamData} = useGetAllTeams();
 
   const accountSectionsRef = useRef<HTMLDivElement>(null);
 
@@ -40,12 +40,12 @@ const AccountSectionWrapper = ({ employeeId }: Props) => {
   }, [employeeData, setEmployee]);
 
   useEffect(() => {
-    if (!isTeamsLoading && teamData) {
+    if (teamData) {
       setProjectTeamNames(
         teamData.map(({ teamId, teamName }) => ({ teamId, teamName }))
       );
     }
-  }, [isTeamsLoading, teamData, setProjectTeamNames]);
+  }, [teamData, setProjectTeamNames]);
 
   const { hasChanged } = useFormChangeDetector();
 

--- a/frontend/src/community/people/components/organisms/AccountSectionWrapper/AccountSectionWrapper.tsx
+++ b/frontend/src/community/people/components/organisms/AccountSectionWrapper/AccountSectionWrapper.tsx
@@ -4,7 +4,6 @@ import { useGetEmployee } from "~community/people/api/PeopleApi";
 import { useGetAllTeams } from "~community/people/api/TeamApi";
 import useFormChangeDetector from "~community/people/hooks/useFormChangeDetector";
 import { usePeopleStore } from "~community/people/store/store";
-import { TeamNamesType } from "~community/people/types/TeamTypes";
 
 import DirectorySteppers from "../../molecules/DirectorySteppers/DirectorySteppers";
 import RouteChangeAreYouSureModal from "../../molecules/RouteChangeAreYouSureModal/RouteChangeAreYouSureModal";

--- a/frontend/src/community/people/components/organisms/TeamModalController/TeamModalController.tsx
+++ b/frontend/src/community/people/components/organisms/TeamModalController/TeamModalController.tsx
@@ -136,7 +136,10 @@ const TeamModalController: FC<Props> = ({ setLatestTeamId }) => {
   };
 
   useEffect(() => {
-    if (!teamsIsLoading && data) setProjectTeamNames(data as TeamNamesType[]);
+    if (!teamsIsLoading && data)
+      setProjectTeamNames(
+        data.map(({ teamId, teamName }) => ({ teamId, teamName }))
+      );
   }, [teamsIsLoading, data]);
 
   const modalContent = (): ReactNode => {

--- a/frontend/src/community/people/components/organisms/TeamModalController/TeamModalController.tsx
+++ b/frontend/src/community/people/components/organisms/TeamModalController/TeamModalController.tsx
@@ -137,9 +137,7 @@ const TeamModalController: FC<Props> = ({ setLatestTeamId }) => {
 
   useEffect(() => {
     if (!teamsIsLoading && data)
-      setProjectTeamNames(
-        data.map(({ teamId, teamName }) => ({ teamId, teamName }))
-      );
+      setProjectTeamNames(data as TeamNamesType[]);
   }, [teamsIsLoading, data]);
 
   const modalContent = (): ReactNode => {


### PR DESCRIPTION
## PR checklist

### TaskId: https://rootcode.skapp.com/pm/projects/SKAPP/items/1703

### Summary

Fixed a bug where team chips were not rendering on the /account Employment tab. Although the employee API correctly returned teamIds, the UI could not resolve these IDs into display names because the global team lookup table was not being populated on this route.

### How to test

1.Navigate to the People module.
2. Open an employee’s profile to view Employment Details.
3. Observe the Teams information under Employment Details.

### Project Checklist

- [x] Changes build without any errors
- [] Have written adequate test cases
- [x] Done developer testing in
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [x] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [] New atomic components added
- [] New molecules added
- [] New pages(routes) added
- [] New dependencies installed

### PR Checklist

- [x] Pull request is raised from the correct source branch
- [x] Pull request is raised to the correct destination branch
- [x] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
