### PR TITLE
fix: add PM access check in getDrawerRoutes for project visibility

### DIFF
--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -141,7 +141,9 @@ const employeeRoutes = {
     ROUTES.SIGN.INFO,
     ROUTES.SIGN.COMPLETE,
     ...commonRoutes
-  ]
+  ],
+  [EmployeeTypes.PM_EMPLOYEE]: [...commonRoutes],
+  [EmployeeTypes.PM_GUEST_EMPLOYEE]: [...commonRoutes]
 };
 
 const senderRoutes = {

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -86,8 +86,7 @@ const adminRoutes = {
     ROUTES.INVOICE.CUSTOMERS.BASE,
     ROUTES.CONFIGURATIONS.BASE,
     ROUTES.INVOICE.CREATE.BASE
-  ],
-  [AdminTypes.PM_ADMIN]: [ROUTES.PROJECTS.BASE, ROUTES.PROJECTS.GUESTS]
+  ]
 };
 
 const managerRoutes = {

--- a/frontend/src/community/common/utils/getDrawerRoutes.ts
+++ b/frontend/src/community/common/utils/getDrawerRoutes.ts
@@ -196,13 +196,11 @@ const getDrawerRoutes = ({
 
         if (!hasPMAccess) return null;
 
-        const isPMAdminOrSuperAdmin = userRoles?.some((role) =>
-          [AdminTypes.SUPER_ADMIN, AdminTypes.PM_ADMIN].includes(
-            role as AdminTypes
-          )
+        const isPMAdmin = userRoles?.some((role) =>
+          [AdminTypes.PM_ADMIN].includes(role as AdminTypes)
         );
 
-        if (isPMAdminOrSuperAdmin) {
+        if (isPMAdmin) {
           const subRoutes = route?.subTree?.filter((subRoute) =>
             subRoute.requiredAuthLevel?.some((requiredRole) =>
               userRoles?.includes(requiredRole as Role)

--- a/frontend/src/community/common/utils/getDrawerRoutes.ts
+++ b/frontend/src/community/common/utils/getDrawerRoutes.ts
@@ -192,11 +192,13 @@ const getDrawerRoutes = ({
 
         if (!hasPMAccess) return null;
 
-        const isPMAdmin = userRoles?.some((role) =>
-          [AdminTypes.PM_ADMIN].includes(role as AdminTypes)
+        const isPMAdminOrSuperAdmin = userRoles?.some((role) =>
+          [AdminTypes.SUPER_ADMIN, AdminTypes.PM_ADMIN].includes(
+            role as AdminTypes
+          )
         );
 
-        if (isPMAdmin) {
+        if (isPMAdminOrSuperAdmin) {
           const subRoutes = route?.subTree?.filter((subRoute) =>
             subRoute.requiredAuthLevel?.some((requiredRole) =>
               userRoles?.includes(requiredRole as Role)

--- a/frontend/src/community/common/utils/getDrawerRoutes.ts
+++ b/frontend/src/community/common/utils/getDrawerRoutes.ts
@@ -186,6 +186,16 @@ const getDrawerRoutes = ({
       }
 
       if (route?.name === "Projects") {
+        const hasPMAccess = userRoles?.some((role) =>
+          [
+            AdminTypes.PM_ADMIN,
+            EmployeeTypes.PM_EMPLOYEE,
+            EmployeeTypes.PM_GUEST_EMPLOYEE
+          ].includes(role as AdminTypes | EmployeeTypes)
+        );
+
+        if (!hasPMAccess) return null;
+
         const isPMAdminOrSuperAdmin = userRoles?.some((role) =>
           [AdminTypes.SUPER_ADMIN, AdminTypes.PM_ADMIN].includes(
             role as AdminTypes

--- a/frontend/src/community/common/utils/getDrawerRoutes.ts
+++ b/frontend/src/community/common/utils/getDrawerRoutes.ts
@@ -187,11 +187,7 @@ const getDrawerRoutes = ({
 
       if (route?.name === "Projects") {
         const hasPMAccess = userRoles?.some((role) =>
-          [
-            AdminTypes.PM_ADMIN,
-            EmployeeTypes.PM_EMPLOYEE,
-            EmployeeTypes.PM_GUEST_EMPLOYEE
-          ].includes(role as AdminTypes | EmployeeTypes)
+          [EmployeeTypes.PM_EMPLOYEE].includes(role as EmployeeTypes)
         );
 
         if (!hasPMAccess) return null;


### PR DESCRIPTION
---

### TaskId: (https://rootcode.skapp.com/pm/projects/SKAPP/items/251)

### Summary

- Fixed a bug where the **Projects navigation item remained visible** in the sidebar after the Project Management (PM) module was turned off via Settings → Modules.

### How to test

1. Log in as a Super Admin .
2. Navigate to **Settings → Modules**.
3. Confirm the Projects module toggle is currently **ON** - Projects should be visible in the left sidebar.
4. Click the toggle on Projects and confirm via the "Turn off (Confirm)" button.
5. Observe the left sidebar  - **Projects should disappear immediately** .
6. Re-enable the Projects module using the same toggle.
7. Observe the left sidebar  - **Projects should reappear immediately**.
8. Repeat steps 1–7 logged in as a `PM_EMPLOYEE` user to verify the same behaviour for non-admin PM users.

### Project Checklist

- [x] Changes build without any errors
- [ ] Have written adequate test cases
- [x] Done developer testing in
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [x] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [x] Pull request is raised from the correct source branch
- [x] Pull request is raised to the correct destination branch
- [x] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)
