### PR TITLE
Fix/715 Error Toast Does Not Appear When Network Error Occurs During Leave Application

### DIFF
--- a/frontend/src/community/common/assets/languages/english/common.json
+++ b/frontend/src/community/common/assets/languages/english/common.json
@@ -235,6 +235,10 @@
       "billing": "Billing"
     }
   },
+  "networkError": {
+    "title": "Oops! Something went wrong.",
+    "description": "No internet connection. Please check your network and try again."
+  },
   "unauthorized": {
     "pageHead": "Access Denied | Skapp",
     "title": "Access Denied",

--- a/frontend/src/community/common/providers/TanStackProvider.tsx
+++ b/frontend/src/community/common/providers/TanStackProvider.tsx
@@ -1,4 +1,8 @@
-import { QueryClient, QueryClientProvider, onlineManager } from "@tanstack/react-query";
+import {
+  QueryClient,
+  QueryClientProvider,
+  onlineManager
+} from "@tanstack/react-query";
 import { ReactNode, useCallback, useEffect, useState } from "react";
 
 import { getNewAccessToken, signOut } from "~community/auth/utils/authUtils";

--- a/frontend/src/community/common/providers/TanStackProvider.tsx
+++ b/frontend/src/community/common/providers/TanStackProvider.tsx
@@ -25,8 +25,12 @@ const TanStackProvider = ({ children }: { children: ReactNode }) => {
   const { user, checkAuth } = useAuth();
   const { setToastMessage } = useToast();
   const translateText = useTranslator("networkError");
+  const offlineToastShown = useRef(false);
 
   const showOfflineToast = useCallback(() => {
+    if (offlineToastShown.current) return;
+    offlineToastShown.current = true;
+    
     setToastMessage({
       open: true,
       toastType: ToastType.ERROR,
@@ -34,6 +38,10 @@ const TanStackProvider = ({ children }: { children: ReactNode }) => {
       description: translateText(["description"]),
       isIcon: true
     });
+
+    setTimeout(() => {
+      offlineToastShown.current = false;
+    }, 3000);
   }, [setToastMessage, translateText]);
 
   const showOfflineToastRef = useRef(showOfflineToast);

--- a/frontend/src/community/common/providers/TanStackProvider.tsx
+++ b/frontend/src/community/common/providers/TanStackProvider.tsx
@@ -1,4 +1,5 @@
 import {
+  MutationCache,
   QueryClient,
   QueryClientProvider,
   onlineManager
@@ -42,11 +43,23 @@ const TanStackProvider = ({ children }: { children: ReactNode }) => {
 
   const [queryClient] = useState(() => {
     return new QueryClient({
+      mutationCache: new MutationCache({
+        onError: (error) => {
+          if (
+            error instanceof Error &&
+            error.message === "Network error: No internet connection"
+          ) {
+            setTimeout(() => {
+              showOfflineToastRef.current();
+            }, 0);
+            return;
+          }
+        }
+      }),
       defaultOptions: {
         mutations: {
           onMutate: async () => {
             if (!onlineManager.isOnline()) {
-              showOfflineToastRef.current();
               throw new Error("Network error: No internet connection");
             }
           }

--- a/frontend/src/community/common/providers/TanStackProvider.tsx
+++ b/frontend/src/community/common/providers/TanStackProvider.tsx
@@ -17,7 +17,7 @@ import { useToast } from "./ToastProvider";
 const TanStackProvider = ({ children }: { children: ReactNode }) => {
   const { user, checkAuth } = useAuth();
   const { setToastMessage } = useToast();
-  
+
   const showOfflineToast = useCallback(() => {
     setToastMessage({
       open: true,

--- a/frontend/src/community/common/providers/TanStackProvider.tsx
+++ b/frontend/src/community/common/providers/TanStackProvider.tsx
@@ -1,5 +1,4 @@
 import {
-  MutationCache,
   QueryClient,
   QueryClientProvider,
   onlineManager
@@ -43,17 +42,11 @@ const TanStackProvider = ({ children }: { children: ReactNode }) => {
 
   const [queryClient] = useState(() => {
     return new QueryClient({
-      mutationCache: new MutationCache({
-        onError: (error) => {
-          if (error instanceof Error && !onlineManager.isOnline()) {
-            showOfflineToastRef.current();
-          }
-        }
-      }),
       defaultOptions: {
         mutations: {
           onMutate: async () => {
             if (!onlineManager.isOnline()) {
+              showOfflineToastRef.current();
               throw new Error("Network error: No internet connection");
             }
           }

--- a/frontend/src/community/common/providers/TanStackProvider.tsx
+++ b/frontend/src/community/common/providers/TanStackProvider.tsx
@@ -1,9 +1,10 @@
 import {
+  MutationCache,
   QueryClient,
   QueryClientProvider,
   onlineManager
 } from "@tanstack/react-query";
-import { ReactNode, useCallback, useEffect, useState } from "react";
+import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
 
 import { getNewAccessToken, signOut } from "~community/auth/utils/authUtils";
 import {
@@ -17,29 +18,42 @@ import authFetch from "~community/common/utils/axiosInterceptor";
 
 import { useAuth } from "../../auth/providers/AuthProvider";
 import { useToast } from "./ToastProvider";
+import { useTranslator } from "../hooks/useTranslator";
 
 const TanStackProvider = ({ children }: { children: ReactNode }) => {
   const { user, checkAuth } = useAuth();
   const { setToastMessage } = useToast();
+  const translateText = useTranslator("networkError");
 
   const showOfflineToast = useCallback(() => {
     setToastMessage({
       open: true,
       toastType: ToastType.ERROR,
-      title: "Oops! Something went wrong.",
-      description:
-        "No internet connection. Please check your network and try again.",
+      title: translateText(["title"]),
+      description: translateText(["description"]),
       isIcon: true
     });
-  }, [setToastMessage]);
+  }, [setToastMessage, translateText]);
+
+  const showOfflineToastRef = useRef(showOfflineToast);
+
+  useEffect(() => {
+    showOfflineToastRef.current = showOfflineToast;
+  }, [showOfflineToast]);
 
   const [queryClient] = useState(() => {
     return new QueryClient({
+      mutationCache: new MutationCache({
+        onError: (error) => {
+          if (error instanceof Error && !onlineManager.isOnline()) {
+            showOfflineToastRef.current();
+          }
+        }
+      }),
       defaultOptions: {
         mutations: {
           onMutate: async () => {
             if (!onlineManager.isOnline()) {
-              showOfflineToast();
               throw new Error("Network error: No internet connection");
             }
           }

--- a/frontend/src/community/common/providers/TanStackProvider.tsx
+++ b/frontend/src/community/common/providers/TanStackProvider.tsx
@@ -24,6 +24,14 @@ const TanStackProvider = ({ children }: { children: ReactNode }) => {
         mutations: {
           onMutate: async () => {
             if (!onlineManager.isOnline()) {
+              setToastMessage({
+                open: true,
+                toastType: ToastType.ERROR,
+                title: "Oops! Something went wrong.",
+                description:
+                  "No internet connection. Please check your network and try again.",
+                isIcon: true
+              });
               throw new Error("Network error: No internet connection");
             }
           }

--- a/frontend/src/community/common/providers/TanStackProvider.tsx
+++ b/frontend/src/community/common/providers/TanStackProvider.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider, onlineManager } from "@tanstack/react-query";
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode, useCallback, useEffect, useState } from "react";
 
 import { getNewAccessToken, signOut } from "~community/auth/utils/authUtils";
 import {
@@ -17,6 +17,17 @@ import { useToast } from "./ToastProvider";
 const TanStackProvider = ({ children }: { children: ReactNode }) => {
   const { user, checkAuth } = useAuth();
   const { setToastMessage } = useToast();
+  
+  const showOfflineToast = useCallback(() => {
+    setToastMessage({
+      open: true,
+      toastType: ToastType.ERROR,
+      title: "Oops! Something went wrong.",
+      description:
+        "No internet connection. Please check your network and try again.",
+      isIcon: true
+    });
+  }, [setToastMessage]);
 
   const [queryClient] = useState(() => {
     return new QueryClient({
@@ -24,14 +35,7 @@ const TanStackProvider = ({ children }: { children: ReactNode }) => {
         mutations: {
           onMutate: async () => {
             if (!onlineManager.isOnline()) {
-              setToastMessage({
-                open: true,
-                toastType: ToastType.ERROR,
-                title: "Oops! Something went wrong.",
-                description:
-                  "No internet connection. Please check your network and try again.",
-                isIcon: true
-              });
+              showOfflineToast();
               throw new Error("Network error: No internet connection");
             }
           }
@@ -51,14 +55,7 @@ const TanStackProvider = ({ children }: { children: ReactNode }) => {
       (response) => response,
       async (error) => {
         if (!onlineManager.isOnline()) {
-          setToastMessage({
-            open: true,
-            toastType: ToastType.ERROR,
-            title: "Oops! Something went wrong.",
-            description:
-              "No internet connection. Please check your network and try again.",
-            isIcon: true
-          });
+          showOfflineToast();
           throw error;
         }
 
@@ -90,7 +87,7 @@ const TanStackProvider = ({ children }: { children: ReactNode }) => {
     return () => {
       authFetch.interceptors.response.eject(interceptor);
     };
-  }, [user, checkAuth, queryClient, setToastMessage]);
+  }, [user, checkAuth, queryClient, showOfflineToast]);
 
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>

--- a/frontend/src/community/common/providers/TanStackProvider.tsx
+++ b/frontend/src/community/common/providers/TanStackProvider.tsx
@@ -15,6 +15,7 @@ import {
 } from "~community/common/constants/errorMessageKeys";
 import { ToastType } from "~community/common/enums/ComponentEnums";
 import authFetch from "~community/common/utils/axiosInterceptor";
+import { NetworkOfflineError } from "~community/common/types/ErrorTypes";
 
 import { useAuth } from "../../auth/providers/AuthProvider";
 import { useToast } from "./ToastProvider";
@@ -45,10 +46,7 @@ const TanStackProvider = ({ children }: { children: ReactNode }) => {
     return new QueryClient({
       mutationCache: new MutationCache({
         onError: (error) => {
-          if (
-            error instanceof Error &&
-            error.message === "Network error: No internet connection"
-          ) {
+          if (error instanceof NetworkOfflineError) {
             setTimeout(() => {
               showOfflineToastRef.current();
             }, 0);
@@ -60,7 +58,7 @@ const TanStackProvider = ({ children }: { children: ReactNode }) => {
         mutations: {
           onMutate: async () => {
             if (!onlineManager.isOnline()) {
-              throw new Error("Network error: No internet connection");
+              throw new NetworkOfflineError();
             }
           }
         }

--- a/frontend/src/community/common/providers/TanStackProvider.tsx
+++ b/frontend/src/community/common/providers/TanStackProvider.tsx
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, onlineManager } from "@tanstack/react-query";
 import { ReactNode, useEffect, useState } from "react";
 
 import { getNewAccessToken, signOut } from "~community/auth/utils/authUtils";
@@ -23,7 +23,7 @@ const TanStackProvider = ({ children }: { children: ReactNode }) => {
       defaultOptions: {
         mutations: {
           onMutate: async () => {
-            if (!navigator.onLine) {
+            if (!onlineManager.isOnline()) {
               throw new Error("Network error: No internet connection");
             }
           }
@@ -42,7 +42,7 @@ const TanStackProvider = ({ children }: { children: ReactNode }) => {
     const interceptor = authFetch.interceptors.response.use(
       (response) => response,
       async (error) => {
-        if (!navigator.onLine) {
+        if (!onlineManager.isOnline()) {
           setToastMessage({
             open: true,
             toastType: ToastType.ERROR,

--- a/frontend/src/community/common/types/ErrorTypes.ts
+++ b/frontend/src/community/common/types/ErrorTypes.ts
@@ -4,3 +4,10 @@ export enum EditAllInfoErrorTypes {
   REALOCATE_INIDIVIDUAL_AND_TEAM_SUPERVISOR_ERROR = "Please assign a supervisor for the members and assign a new Team Lead for the Team in order to change the users permission",
   UPLOAD_PROFILE_PICTURE_ERROR = "Uploading failed"
 }
+
+export class NetworkOfflineError extends Error {
+  constructor() {
+    super("Network error: No internet connection");
+    this.name = "NetworkOfflineError";
+  }
+}

--- a/frontend/src/community/leave/api/MyRequestApi.ts
+++ b/frontend/src/community/leave/api/MyRequestApi.ts
@@ -145,7 +145,7 @@ export const useApplyLeave = (
       onSuccess(data);
     },
     onError: (error: ErrorResponse) => {
-      onError(error.response.data.results[0]?.messageKey || "");
+      onError(error.response?.data?.results?.[0]?.messageKey ?? "");
     }
   });
 };


### PR DESCRIPTION
## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/1012)

### Summary

I found a PR addressed about the network toast issue [1]. The previous approach used `navigator.onLine` [3], but this is not reliable in Chromium-based browsers due to known false negatives. TanStack Query explicitly moved away from navigator.onLine for this reason and instead tracks connectivity through window online and offline events via its online manager.[2]

Becaus `onlineManager.isOnline()[2]`. This matches TanStack internal behavior and gives more consistent results for mutation/query lifecycle handling.

tanStack uses window.addEventListener for the online [5] event to track connectivity changes [4] not navigator.online

So I concluded using onlineManager.isOnline is the safer and more consistent choice for network toast handling.

[1] https://github.com/SkappHQ/skapp/pull/1150
[2] https://tanstack.com/query/v5/docs/reference/onlineManager#onlinemanagerisonline
[3] https://developer.mozilla.org/en-US/docs/Web/API/Navigator/onLine
[4] https://github.com/TanStack/query/blob/65f9eeb46192a2d9e1c8c00891c5716332782906/packages/query-core/src/onlineManager.ts#L21
[5] https://developer.mozilla.org/en-US/docs/Web/API/Window/online_event


### How to test

1.

### Project Checklist

- [x] Changes build without any errors
- [ ] Have written adequate test cases
- [x] Done developer testing in
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
- [x] Code is formatted with `npm run format`
- [x] Code is linted with `npm run check-lint`
- [x] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [x] Pull request is raised from the correct source branch
- [x] Pull request is raised to the correct destination branch
- [x] Pull request is raised with correct title
- [x] Pull request is self reviewed
- [x] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
