### PR TITLE
fix: isolate community tests from enterprise multi-tenant context

### DIFF
--- a/backend/src/main/java/com/skapp/community/peopleplanner/constant/PeopleMessageConstant.java
+++ b/backend/src/main/java/com/skapp/community/peopleplanner/constant/PeopleMessageConstant.java
@@ -18,6 +18,8 @@ public enum PeopleMessageConstant implements MessageConstant {
 	PEOPLE_SUCCESS_EMPLOYEE_ADDED("api.success.people.employee-added"),
 	PEOPLE_SUCCESS_EMPLOYEE_TERMINATED("api.success.people.employee-terminated"),
 	PEOPLE_SUCCESS_EMPLOYEE_DELETED("api.success.people.employee-deleted"),
+	PEOPLE_SUCCESS_DELETE_HOLIDAYS("api.success.people.delete-holidays"),
+	PEOPLE_SUCCESS_DELETE_SELECTED_HOLIDAYS("api.success.people.delete-selected-holidays"),
 
 	// Error messages
 	PEOPLE_ERROR_TEAM_SUPERVISOR_IDS_NOT_VALID("api.error.people.notnull.team.supervisors.invalid"),

--- a/backend/src/main/java/com/skapp/community/peopleplanner/service/impl/HolidayServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/peopleplanner/service/impl/HolidayServiceImpl.java
@@ -203,7 +203,8 @@ public class HolidayServiceImpl implements HolidayService {
 		List<Long> deletedHolidayIds = holidays.stream().filter(this::canDeleteHoliday).map(Holiday::getId).toList();
 		holidayDao.deleteAllById(deletedHolidayIds);
 
-		return new ResponseEntityDto("holidays deleted successfully", false);
+		return new ResponseEntityDto(messageUtil.getMessage(PeopleMessageConstant.PEOPLE_SUCCESS_DELETE_HOLIDAYS),
+				false);
 	}
 
 	@Override
@@ -250,7 +251,8 @@ public class HolidayServiceImpl implements HolidayService {
 			}
 		}
 
-		return new ResponseEntityDto("Selected holidays deleted successfully.", false);
+		return new ResponseEntityDto(
+				messageUtil.getMessage(PeopleMessageConstant.PEOPLE_SUCCESS_DELETE_SELECTED_HOLIDAYS), false);
 	}
 
 	private void updateLeaveRequestDueHoliday(Holiday holiday, LeaveRequest leaveRequest) {

--- a/backend/src/main/resources/community/messages/people-messages.properties
+++ b/backend/src/main/resources/community/messages/people-messages.properties
@@ -93,6 +93,7 @@ api.error.people.super-admin-required=Super admin is required
 api.error.people.people-role-required=People's role is required
 api.error.people.attendance-role-required=Attendance role is required
 api.error.people.leave-role-required=Leave role is required
+api.error.people.invoice-role-required=Invoice role is required
 api.error.people.invalid-people-role=Invalid people role: {0}
 api.error.people.invalid-attendance-role=Invalid attendance role: {0}
 api.error.people.invalid-leave-role=Invalid leave role: {0}

--- a/backend/src/main/resources/community/messages/people-messages.properties
+++ b/backend/src/main/resources/community/messages/people-messages.properties
@@ -168,3 +168,5 @@ api.success.people.team-deleted=Delete Team successfully after transfer members 
 api.success.people.employee-added=Employee added successfully
 api.success.people.employee-terminated=Employee terminated successfully
 api.success.people.employee-deleted=Employee deleted successfully
+api.success.people.delete-holidays=holidays deleted successfully
+api.success.people.delete-selected-holidays=Selected holidays deleted successfully.

--- a/backend/src/test/java/com/skapp/SkappApplicationTests.java
+++ b/backend/src/test/java/com/skapp/SkappApplicationTests.java
@@ -3,7 +3,7 @@ package com.skapp;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest(classes = SkappApplication.class)
+@SpringBootTest(classes = TestSkappApplication.class)
 class SkappApplicationTests {
 
 	@Test

--- a/backend/src/test/java/com/skapp/TestSkappApplication.java
+++ b/backend/src/test/java/com/skapp/TestSkappApplication.java
@@ -1,0 +1,23 @@
+package com.skapp;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@EnableAsync
+@SpringBootApplication(scanBasePackages = "com.skapp.community")
+@EnableCaching
+@EnableRetry
+@EntityScan(basePackages = { "com.skapp.community.peopleplanner.model", "com.skapp.community.common.model",
+		"com.skapp.community.timeplanner.model", "com.skapp.community.leaveplanner.model",
+		"com.skapp.community.okrplanner.model" })
+@EnableJpaRepositories(basePackages = { "com.skapp.community.common.repository",
+		"com.skapp.community.peopleplanner.repository", "com.skapp.community.leaveplanner.repository",
+		"com.skapp.community.timeplanner.repository", "com.skapp.community.okrplanner.repository" })
+public class TestSkappApplication implements AsyncConfigurer {
+
+}

--- a/backend/src/test/java/com/skapp/community/common/controller/v1/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/common/controller/v1/AuthControllerIntegrationTest.java
@@ -12,8 +12,12 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.databind.json.JsonMapper;
 
+import static com.skapp.support.TestConstants.RESULTS_0_PATH;
+import static com.skapp.support.TestConstants.STATUS_PATH;
+import static com.skapp.support.TestConstants.STATUS_SUCCESSFUL;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -21,15 +25,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest(classes = TestSkappApplication.class)
 @AutoConfigureMockMvc
+@Transactional
 @RequiredArgsConstructor
 @DisplayName("Auth Controller Integration Tests")
 class AuthControllerIntegrationTest {
-
-	private static final String STATUS_PATH = "['status']";
-
-	private static final String RESULTS_0_PATH = "['results'][0]";
-
-	private static final String STATUS_SUCCESSFUL = "successful";
 
 	private final JsonMapper objectMapper;
 

--- a/backend/src/test/java/com/skapp/community/common/controller/v1/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/common/controller/v1/AuthControllerIntegrationTest.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import com.skapp.TestSkappApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
@@ -18,7 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@SpringBootTest(classes = TestSkappApplication.class)
 @AutoConfigureMockMvc
 @RequiredArgsConstructor
 @DisplayName("Auth Controller Integration Tests")

--- a/backend/src/test/java/com/skapp/community/common/controller/v1/AuthControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/common/controller/v1/AuthControllerIntegrationTest.java
@@ -1,11 +1,11 @@
 package com.skapp.community.common.controller.v1;
 
 import com.skapp.community.common.payload.request.SignInRequestDto;
+import com.skapp.TestSkappApplication;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import com.skapp.TestSkappApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;

--- a/backend/src/test/java/com/skapp/community/common/controller/v1/OrganizationControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/common/controller/v1/OrganizationControllerIntegrationTest.java
@@ -1,37 +1,33 @@
 package com.skapp.community.common.controller.v1;
 
+import com.skapp.TestSkappApplication;
 import com.skapp.community.common.constant.CommonMessageConstant;
-import com.skapp.community.common.model.User;
 import com.skapp.community.common.payload.request.OrganizationDto;
 import com.skapp.community.common.payload.request.UpdateOrganizationRequestDto;
 import com.skapp.community.common.security.AuthorityService;
-import com.skapp.community.common.security.SkappUserDetails;
 import com.skapp.community.common.service.JwtService;
-import com.skapp.community.common.type.Role;
 import com.skapp.community.common.util.MessageUtil;
-import com.skapp.community.peopleplanner.model.Employee;
-import com.skapp.community.peopleplanner.model.EmployeeRole;
+import com.skapp.support.MockUserFactory;
+import com.skapp.support.SecurityTestUtils;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
-import com.skapp.TestSkappApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.databind.json.JsonMapper;
 
+import static com.skapp.support.TestConstants.MESSAGE_PATH;
+import static com.skapp.support.TestConstants.RESULTS_0_PATH;
+import static com.skapp.support.TestConstants.STATUS_PATH;
+import static com.skapp.support.TestConstants.STATUS_SUCCESSFUL;
+import static com.skapp.support.TestConstants.STATUS_UNSUCCESSFUL;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -41,22 +37,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest(classes = TestSkappApplication.class)
 @AutoConfigureMockMvc
+@Transactional
 @RequiredArgsConstructor
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @DisplayName("Organization Controller Integration Tests")
 class OrganizationControllerIntegrationTest {
 
 	private static final String BASE_PATH = "/v1/organization";
-
-	private static final String STATUS_PATH = "['status']";
-
-	private static final String RESULTS_0_PATH = "['results'][0]";
-
-	private static final String MESSAGE_PATH = "['message']";
-
-	private static final String STATUS_SUCCESSFUL = "successful";
-
-	private static final String STATUS_UNSUCCESSFUL = "unsuccessful";
 
 	private final AuthorityService authorityService;
 
@@ -74,19 +60,12 @@ class OrganizationControllerIntegrationTest {
 
 	@BeforeEach
 	void setup() {
-		setupSecurityContext();
+		SecurityTestUtils.setupSecurityContext(authorityService, MockUserFactory.createSuperAdmin());
 		authToken = jwtService.generateAccessToken(userDetailsService.loadUserByUsername("user1@gmail.com"), 1L);
 	}
 
-	private RequestPostProcessor bearerToken() {
-		return request -> {
-			request.addHeader("Authorization", "Bearer " + authToken);
-			return request;
-		};
-	}
-
 	private ResultActions performRequest(MockHttpServletRequestBuilder request) throws Exception {
-		return mvc.perform(request.with(bearerToken()));
+		return mvc.perform(request.with(SecurityTestUtils.bearerToken(authToken)));
 	}
 
 	private ResultActions performGetRequest() throws Exception {
@@ -107,45 +86,7 @@ class OrganizationControllerIntegrationTest {
 					.accept(MediaType.APPLICATION_JSON));
 	}
 
-	private void setupSecurityContext() {
-		User mockUser = createMockUser();
-		SkappUserDetails userDetails = SkappUserDetails.builder()
-			.username(mockUser.getEmail())
-			.password(mockUser.getPassword())
-			.enabled(mockUser.getIsActive())
-			.authorities(authorityService.getAuthorities(mockUser))
-			.build();
-
-		UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null,
-				userDetails.getAuthorities());
-
-		SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-		securityContext.setAuthentication(authentication);
-		SecurityContextHolder.setContext(securityContext);
-	}
-
-	private User createMockUser() {
-		User mockUser = new User();
-		mockUser.setEmail("user1@gmail.com");
-		mockUser.setPassword("$2a$12$CGe4n75Yejv/O8dnOTD7R.x0LruTiKM22kcdc3YNl4RRw01srJsB6");
-		mockUser.setIsActive(true);
-
-		Employee mockEmployee = new Employee();
-		mockEmployee.setEmployeeId(1L);
-		mockEmployee.setFirstName("name");
-
-		EmployeeRole role = new EmployeeRole();
-		role.setAttendanceRole(Role.SUPER_ADMIN);
-		role.setIsSuperAdmin(true);
-
-		mockEmployee.setEmployeeRole(role);
-		mockUser.setEmployee(mockEmployee);
-
-		return mockUser;
-	}
-
 	@Test
-	@Order(2)
 	@DisplayName("Create organization with all fields - Returns Created")
 	void createOrganization_ReturnsCreated() throws Exception {
 		OrganizationDto organizationDto = new OrganizationDto();
@@ -160,7 +101,6 @@ class OrganizationControllerIntegrationTest {
 	}
 
 	@Test
-	@Order(1)
 	@DisplayName("Create organization with only name - Returns Unprocessed Entity")
 	void createOrganizationOnlyWithName_ReturnsUnprocessedEntity() throws Exception {
 		OrganizationDto organizationDto = new OrganizationDto();
@@ -176,9 +116,15 @@ class OrganizationControllerIntegrationTest {
 	}
 
 	@Test
-	@Order(3)
 	@DisplayName("Get organization - Returns OK")
 	void getOrganization_ReturnsOk() throws Exception {
+		// Setup: create organization first
+		OrganizationDto organizationDto = new OrganizationDto();
+		organizationDto.setOrganizationName("Org");
+		organizationDto.setCountry("Canada");
+		organizationDto.setOrganizationTimeZone("Asia/Kolkata");
+		performPostRequest(organizationDto);
+
 		performGetRequest().andDo(print())
 			.andExpect(status().isOk())
 			.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
@@ -187,9 +133,15 @@ class OrganizationControllerIntegrationTest {
 	}
 
 	@Test
-	@Order(4)
 	@DisplayName("Update organization name - Returns OK")
 	void updateOrganizationName_ReturnsOk() throws Exception {
+		// Setup: create organization first
+		OrganizationDto setupDto = new OrganizationDto();
+		setupDto.setOrganizationName("Org");
+		setupDto.setCountry("Canada");
+		setupDto.setOrganizationTimeZone("Asia/Kolkata");
+		performPostRequest(setupDto);
+
 		UpdateOrganizationRequestDto organizationDto = new UpdateOrganizationRequestDto();
 		organizationDto.setOrganizationName("NewOrg");
 

--- a/backend/src/test/java/com/skapp/community/common/controller/v1/OrganizationControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/common/controller/v1/OrganizationControllerIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.skapp.community.common.controller.v1;
 
-import com.skapp.TestSkappApplication;
 import com.skapp.community.common.constant.CommonMessageConstant;
 import com.skapp.community.common.payload.request.OrganizationDto;
 import com.skapp.community.common.payload.request.UpdateOrganizationRequestDto;
@@ -9,6 +8,7 @@ import com.skapp.community.common.service.JwtService;
 import com.skapp.community.common.util.MessageUtil;
 import com.skapp.support.MockUserFactory;
 import com.skapp.support.SecurityTestUtils;
+import com.skapp.TestSkappApplication;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/backend/src/test/java/com/skapp/community/common/controller/v1/OrganizationControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/common/controller/v1/OrganizationControllerIntegrationTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import com.skapp.TestSkappApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
@@ -38,7 +39,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@SpringBootTest(classes = TestSkappApplication.class)
 @AutoConfigureMockMvc
 @RequiredArgsConstructor
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeaveAnalyticsControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeaveAnalyticsControllerIntegrationTest.java
@@ -1,10 +1,10 @@
 package com.skapp.community.leaveplanner.controller.v1;
 
-import com.skapp.TestSkappApplication;
 import com.skapp.community.common.security.AuthorityService;
 import com.skapp.community.common.service.JwtService;
 import com.skapp.support.MockUserFactory;
 import com.skapp.support.SecurityTestUtils;
+import com.skapp.TestSkappApplication;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeaveAnalyticsControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeaveAnalyticsControllerIntegrationTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import com.skapp.TestSkappApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
@@ -34,7 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@SpringBootTest(classes = TestSkappApplication.class)
 @AutoConfigureMockMvc
 @DisplayName("Leave Analytics Controller Integration Tests")
 class LeaveAnalyticsControllerIntegrationTest {

--- a/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeaveAnalyticsControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeaveAnalyticsControllerIntegrationTest.java
@@ -1,35 +1,30 @@
 package com.skapp.community.leaveplanner.controller.v1;
 
-import com.skapp.community.common.model.User;
+import com.skapp.TestSkappApplication;
 import com.skapp.community.common.security.AuthorityService;
-import com.skapp.community.common.security.SkappUserDetails;
 import com.skapp.community.common.service.JwtService;
-import com.skapp.community.common.type.Role;
-import com.skapp.community.peopleplanner.model.Employee;
-import com.skapp.community.peopleplanner.model.EmployeeRole;
+import com.skapp.support.MockUserFactory;
+import com.skapp.support.SecurityTestUtils;
+import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import com.skapp.TestSkappApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 import java.time.LocalDate;
 import java.time.Month;
 
+import static com.skapp.support.TestConstants.RESULTS_0_PATH;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -37,82 +32,33 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest(classes = TestSkappApplication.class)
 @AutoConfigureMockMvc
+@Transactional
+@RequiredArgsConstructor
 @DisplayName("Leave Analytics Controller Integration Tests")
 class LeaveAnalyticsControllerIntegrationTest {
 
-	private static final String RESULTS_0_PATH = "['results'][0]";
+	private final AuthorityService authorityService;
 
-	@Autowired
-	private AuthorityService authorityService;
+	private final JwtService jwtService;
 
-	@Autowired
-	private JwtService jwtService;
+	private final UserDetailsService userDetailsService;
 
-	@Autowired
-	private UserDetailsService userDetailsService;
-
-	@Autowired
-	private MockMvc mvc;
+	private final MockMvc mvc;
 
 	private String authToken;
 
 	@BeforeEach
 	void setup() {
-		setupSecurityContext();
+		SecurityTestUtils.setupSecurityContext(authorityService, MockUserFactory.createLeaveAdmin());
 		authToken = jwtService.generateAccessToken(userDetailsService.loadUserByUsername("user1@gmail.com"), 1L);
 	}
 
-	private RequestPostProcessor bearerToken() {
-		return request -> {
-			request.addHeader("Authorization", "Bearer " + authToken);
-			return request;
-		};
-	}
-
 	private ResultActions performRequest(MockHttpServletRequestBuilder request) throws Exception {
-		return mvc.perform(request.with(bearerToken()));
+		return mvc.perform(request.with(SecurityTestUtils.bearerToken(authToken)));
 	}
 
 	private ResultActions performGetRequestWithParams(MultiValueMap<String, String> params) throws Exception {
 		return performRequest(get("/v1/leave/analytics/all/leaves").params(params).accept(MediaType.APPLICATION_JSON));
-	}
-
-	private void setupSecurityContext() {
-		User mockUser = createMockUser();
-		SkappUserDetails userDetails = SkappUserDetails.builder()
-			.username(mockUser.getEmail())
-			.password(mockUser.getPassword())
-			.enabled(mockUser.getIsActive())
-			.authorities(authorityService.getAuthorities(mockUser))
-			.build();
-
-		UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null,
-				userDetails.getAuthorities());
-
-		SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-		securityContext.setAuthentication(authentication);
-		SecurityContextHolder.setContext(securityContext);
-	}
-
-	private User createMockUser() {
-		User mockUser = new User();
-		mockUser.setUserId(1L);
-		mockUser.setEmail("user1@gmail.com");
-		mockUser.setPassword("$2a$12$CGe4n75Yejv/O8dnOTD7R.x0LruTiKM22kcdc3YNl4RRw01srJsB6");
-		mockUser.setIsActive(true);
-
-		Employee mockEmployee = new Employee();
-		mockEmployee.setEmployeeId(1L);
-		mockEmployee.setFirstName("name");
-
-		EmployeeRole role = new EmployeeRole();
-		role.setLeaveRole(Role.LEAVE_ADMIN);
-		role.setIsSuperAdmin(true);
-
-		mockEmployee.setEmployeeRole(role);
-		mockUser.setEmployee(mockEmployee);
-
-		return mockUser;
 	}
 
 	private MultiValueMap<String, String> createDefaultLeaveRequestParams(String status) {

--- a/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeaveControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeaveControllerIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.skapp.community.leaveplanner.controller.v1;
 
-import com.skapp.TestSkappApplication;
 import com.skapp.community.common.security.AuthorityService;
 import com.skapp.community.common.service.JwtService;
 import com.skapp.community.common.util.DateTimeUtils;
@@ -11,6 +10,7 @@ import com.skapp.community.leaveplanner.type.LeaveRequestStatus;
 import com.skapp.community.leaveplanner.type.LeaveState;
 import com.skapp.support.MockUserFactory;
 import com.skapp.support.SecurityTestUtils;
+import com.skapp.TestSkappApplication;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeaveControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeaveControllerIntegrationTest.java
@@ -1,36 +1,36 @@
 package com.skapp.community.leaveplanner.controller.v1;
 
-import com.skapp.community.common.model.User;
+import com.skapp.TestSkappApplication;
 import com.skapp.community.common.security.AuthorityService;
-import com.skapp.community.common.security.SkappUserDetails;
 import com.skapp.community.common.service.JwtService;
-import com.skapp.community.common.type.Role;
 import com.skapp.community.common.util.DateTimeUtils;
+import com.skapp.community.common.util.MessageUtil;
+import com.skapp.community.leaveplanner.constant.LeaveMessageConstant;
 import com.skapp.community.leaveplanner.payload.request.LeaveRequestDto;
 import com.skapp.community.leaveplanner.type.LeaveRequestStatus;
 import com.skapp.community.leaveplanner.type.LeaveState;
-import com.skapp.community.peopleplanner.model.Employee;
-import com.skapp.community.peopleplanner.model.EmployeeRole;
+import com.skapp.support.MockUserFactory;
+import com.skapp.support.SecurityTestUtils;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import com.skapp.TestSkappApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.databind.json.JsonMapper;
 
+import static com.skapp.support.TestConstants.MESSAGE_PATH;
+import static com.skapp.support.TestConstants.RESULTS_0_PATH;
+import static com.skapp.support.TestConstants.STATUS_PATH;
+import static com.skapp.support.TestConstants.STATUS_SUCCESSFUL;
+import static com.skapp.support.TestConstants.STATUS_UNSUCCESSFUL;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -38,97 +38,41 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest(classes = TestSkappApplication.class)
 @AutoConfigureMockMvc
+@Transactional
 @RequiredArgsConstructor
 @DisplayName("Leave Controller Integration Tests")
 class LeaveControllerIntegrationTest {
 
 	private static final String BASE_PATH = "/v1/leave";
 
-	private static final String STATUS_PATH = "['status']";
-
-	private static final String RESULTS_0_PATH = "['results'][0]";
-
-	private static final String MESSAGE_PATH = "['message']";
-
-	private static final String STATUS_SUCCESSFUL = "successful";
-
-	private static final String STATUS_UNSUCCESSFUL = "unsuccessful";
-
 	private final JsonMapper objectMapper;
 
-	@Autowired
-	private AuthorityService authorityService;
+	private final AuthorityService authorityService;
 
-	@Autowired
-	private JwtService jwtService;
+	private final JwtService jwtService;
 
-	@Autowired
-	private UserDetailsService userDetailsService;
+	private final UserDetailsService userDetailsService;
 
-	@Autowired
-	private MockMvc mvc;
+	private final MockMvc mvc;
+
+	private final MessageUtil messageUtil;
 
 	private String authToken;
 
 	@BeforeEach
 	void setup() {
-		setupSecurityContext();
+		SecurityTestUtils.setupSecurityContext(authorityService, MockUserFactory.createLeaveEmployee());
 		authToken = jwtService.generateAccessToken(userDetailsService.loadUserByUsername("user2@gmail.com"), 2L);
 	}
 
-	private RequestPostProcessor bearerToken() {
-		return request -> {
-			request.addHeader("Authorization", "Bearer " + authToken);
-			return request;
-		};
-	}
-
 	private ResultActions performRequest(MockHttpServletRequestBuilder request) throws Exception {
-		return mvc.perform(request.with(bearerToken()));
+		return mvc.perform(request.with(SecurityTestUtils.bearerToken(authToken)));
 	}
 
 	private <T> ResultActions performPostRequest(T content) throws Exception {
 		return performRequest(post(LeaveControllerIntegrationTest.BASE_PATH).contentType(MediaType.APPLICATION_JSON)
 			.content(objectMapper.writeValueAsString(content))
 			.accept(MediaType.APPLICATION_JSON));
-	}
-
-	private void setupSecurityContext() {
-		User mockUser = createMockUser();
-		SkappUserDetails userDetails = SkappUserDetails.builder()
-			.username(mockUser.getEmail())
-			.password(mockUser.getPassword())
-			.enabled(mockUser.getIsActive())
-			.authorities(authorityService.getAuthorities(mockUser))
-			.build();
-
-		UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null,
-				userDetails.getAuthorities());
-
-		SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-		securityContext.setAuthentication(authentication);
-		SecurityContextHolder.setContext(securityContext);
-	}
-
-	private User createMockUser() {
-		User mockUser = new User();
-		mockUser.setEmail("user2@gmail.com");
-		mockUser.setPassword("$2a$12$CGe4n75Yejv/O8dnOTD7R.x0LruTiKM22kcdc3YNl4RRw01srJsB6");
-		mockUser.setIsActive(true);
-		mockUser.setUserId(2L);
-
-		Employee mockEmployee = new Employee();
-		mockEmployee.setEmployeeId(2L);
-		mockEmployee.setFirstName("name");
-
-		EmployeeRole role = new EmployeeRole();
-		role.setLeaveRole(Role.LEAVE_EMPLOYEE);
-		role.setIsSuperAdmin(true);
-
-		mockEmployee.setEmployeeRole(role);
-		mockUser.setEmployee(mockEmployee);
-
-		return mockUser;
 	}
 
 	private LeaveRequestDto createFullDayLeaveRequest() {
@@ -178,7 +122,7 @@ class LeaveControllerIntegrationTest {
 				.andExpect(status().isBadRequest())
 				.andExpect(jsonPath(STATUS_PATH).value(STATUS_UNSUCCESSFUL))
 				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH)
-					.value("Comment must be included for the selected leave type"));
+					.value(messageUtil.getMessage(LeaveMessageConstant.LEAVE_ERROR_MUST_INCLUDE_COMMENT)));
 		}
 
 	}

--- a/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeaveControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeaveControllerIntegrationTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import com.skapp.TestSkappApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
@@ -35,7 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@SpringBootTest(classes = TestSkappApplication.class)
 @AutoConfigureMockMvc
 @RequiredArgsConstructor
 @DisplayName("Leave Controller Integration Tests")

--- a/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/HolidayControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/HolidayControllerIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.skapp.community.peopleplanner.controller.v1;
 
-import com.skapp.TestSkappApplication;
 import com.skapp.community.common.security.AuthorityService;
 import com.skapp.community.common.service.JwtService;
 import com.skapp.community.common.util.DateTimeUtils;
@@ -11,6 +10,7 @@ import com.skapp.community.peopleplanner.payload.request.HolidayRequestDto;
 import com.skapp.community.peopleplanner.payload.request.HolidaysDeleteRequestDto;
 import com.skapp.support.MockUserFactory;
 import com.skapp.support.SecurityTestUtils;
+import com.skapp.TestSkappApplication;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/HolidayControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/HolidayControllerIntegrationTest.java
@@ -1,33 +1,29 @@
 package com.skapp.community.peopleplanner.controller.v1;
 
-import com.skapp.community.common.model.User;
+import com.skapp.TestSkappApplication;
 import com.skapp.community.common.security.AuthorityService;
-import com.skapp.community.common.security.SkappUserDetails;
 import com.skapp.community.common.service.JwtService;
-import com.skapp.community.common.type.Role;
 import com.skapp.community.common.util.DateTimeUtils;
-import com.skapp.community.peopleplanner.model.Employee;
-import com.skapp.community.peopleplanner.model.EmployeeRole;
+import com.skapp.community.common.util.MessageUtil;
+import com.skapp.community.peopleplanner.constant.PeopleMessageConstant;
 import com.skapp.community.peopleplanner.payload.request.HolidayBulkRequestDto;
 import com.skapp.community.peopleplanner.payload.request.HolidayRequestDto;
 import com.skapp.community.peopleplanner.payload.request.HolidaysDeleteRequestDto;
+import com.skapp.support.MockUserFactory;
+import com.skapp.support.SecurityTestUtils;
+import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import com.skapp.TestSkappApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import tools.jackson.databind.json.JsonMapper;
@@ -35,6 +31,10 @@ import tools.jackson.databind.json.JsonMapper;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.skapp.support.TestConstants.MESSAGE_PATH;
+import static com.skapp.support.TestConstants.RESULTS_0_PATH;
+import static com.skapp.support.TestConstants.STATUS_PATH;
+import static com.skapp.support.TestConstants.STATUS_SUCCESSFUL;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -44,53 +44,37 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest(classes = TestSkappApplication.class)
 @AutoConfigureMockMvc
+@Transactional
+@RequiredArgsConstructor
 @DisplayName("Holiday Controller Integration Tests")
 class HolidayControllerIntegrationTest {
 
 	private static final String BASE_PATH = "/v1/holiday";
 
-	private static final String STATUS_PATH = "['status']";
-
-	private static final String RESULTS_0_PATH = "['results'][0]";
-
-	private static final String MESSAGE_PATH = "['message']";
-
-	private static final String STATUS_SUCCESSFUL = "successful";
-
 	private static final String FULL_DAY = "FULL_DAY";
 
-	@Autowired
-	private AuthorityService authorityService;
+	private final AuthorityService authorityService;
 
-	@Autowired
-	private JsonMapper objectMapper;
+	private final JsonMapper objectMapper;
 
-	@Autowired
-	private JwtService jwtService;
+	private final JwtService jwtService;
 
-	@Autowired
-	private UserDetailsService userDetailsService;
+	private final UserDetailsService userDetailsService;
 
-	@Autowired
-	private MockMvc mvc;
+	private final MockMvc mvc;
+
+	private final MessageUtil messageUtil;
 
 	private String authToken;
 
 	@BeforeEach
 	void setup() {
-		setupSecurityContext();
+		SecurityTestUtils.setupSecurityContext(authorityService, MockUserFactory.createSuperAdmin());
 		authToken = jwtService.generateAccessToken(userDetailsService.loadUserByUsername("user1@gmail.com"), 1L);
 	}
 
-	private RequestPostProcessor bearerToken() {
-		return request -> {
-			request.addHeader("Authorization", "Bearer " + authToken);
-			return request;
-		};
-	}
-
 	private ResultActions performRequest(MockHttpServletRequestBuilder request) throws Exception {
-		return mvc.perform(request.with(bearerToken()));
+		return mvc.perform(request.with(SecurityTestUtils.bearerToken(authToken)));
 	}
 
 	private ResultActions performGetRequest() throws Exception {
@@ -116,42 +100,6 @@ class HolidayControllerIntegrationTest {
 
 	private ResultActions performDeleteRequest(String path) throws Exception {
 		return performRequest(delete(path).accept(MediaType.APPLICATION_JSON));
-	}
-
-	private void setupSecurityContext() {
-		User mockUser = createMockUser();
-		SkappUserDetails userDetails = SkappUserDetails.builder()
-			.username(mockUser.getEmail())
-			.password(mockUser.getPassword())
-			.enabled(mockUser.getIsActive())
-			.authorities(authorityService.getAuthorities(mockUser))
-			.build();
-
-		UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null,
-				userDetails.getAuthorities());
-
-		SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-		securityContext.setAuthentication(authentication);
-		SecurityContextHolder.setContext(securityContext);
-	}
-
-	private User createMockUser() {
-		User mockUser = new User();
-		mockUser.setEmail("user1@gmail.com");
-		mockUser.setPassword("$2a$12$CGe4n75Yejv/O8dnOTD7R.x0LruTiKM22kcdc3YNl4RRw01srJsB6");
-		mockUser.setIsActive(true);
-
-		Employee mockEmployee = new Employee();
-		mockEmployee.setEmployeeId(1L);
-		mockEmployee.setFirstName("name");
-
-		EmployeeRole role = new EmployeeRole();
-		role.setAttendanceRole(Role.SUPER_ADMIN);
-		role.setIsSuperAdmin(true);
-		mockEmployee.setEmployeeRole(role);
-		mockUser.setEmployee(mockEmployee);
-
-		return mockUser;
 	}
 
 	private HolidayRequestDto createHolidayDto(String date, String name) {
@@ -236,7 +184,8 @@ class HolidayControllerIntegrationTest {
 			performDeleteRequest(holidaysDeleteRequestDto).andDo(print())
 				.andExpect(status().isOk())
 				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
-				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH).value("Selected holidays deleted successfully."));
+				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH)
+					.value(messageUtil.getMessage(PeopleMessageConstant.PEOPLE_SUCCESS_DELETE_SELECTED_HOLIDAYS)));
 		}
 
 		@Test
@@ -245,7 +194,8 @@ class HolidayControllerIntegrationTest {
 			performDeleteRequest(BASE_PATH + "/" + DateTimeUtils.getCurrentYear()).andDo(print())
 				.andExpect(status().isOk())
 				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
-				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH).value("holidays deleted successfully"));
+				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH)
+					.value(messageUtil.getMessage(PeopleMessageConstant.PEOPLE_SUCCESS_DELETE_HOLIDAYS)));
 		}
 
 	}

--- a/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/HolidayControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/HolidayControllerIntegrationTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import com.skapp.TestSkappApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
@@ -41,7 +42,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@SpringBootTest(classes = TestSkappApplication.class)
 @AutoConfigureMockMvc
 @DisplayName("Holiday Controller Integration Tests")
 class HolidayControllerIntegrationTest {

--- a/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/JobControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/JobControllerIntegrationTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import com.skapp.TestSkappApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
@@ -40,7 +41,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@SpringBootTest(classes = TestSkappApplication.class)
 @AutoConfigureMockMvc
 @DisplayName("Job Controller Integration Tests")
 class JobControllerIntegrationTest {

--- a/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/JobControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/JobControllerIntegrationTest.java
@@ -1,39 +1,41 @@
 package com.skapp.community.peopleplanner.controller.v1;
 
-import com.skapp.community.common.model.User;
+import com.skapp.TestSkappApplication;
 import com.skapp.community.common.security.AuthorityService;
-import com.skapp.community.common.security.SkappUserDetails;
 import com.skapp.community.common.service.JwtService;
-import com.skapp.community.common.type.Role;
-import com.skapp.community.peopleplanner.model.Employee;
-import com.skapp.community.peopleplanner.model.EmployeeRole;
+import com.skapp.community.common.util.MessageUtil;
+import com.skapp.community.peopleplanner.constant.PeopleMessageConstant;
 import com.skapp.community.peopleplanner.payload.request.JobFamilyDto;
 import com.skapp.community.peopleplanner.payload.request.JobTitleDto;
 import com.skapp.community.peopleplanner.payload.request.TransferJobTitleRequestDto;
 import com.skapp.community.peopleplanner.payload.request.UpdateJobFamilyRequestDto;
+import com.skapp.support.MockUserFactory;
+import com.skapp.support.SecurityTestUtils;
+import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import com.skapp.TestSkappApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static com.skapp.support.TestConstants.MESSAGE_PATH;
+import static com.skapp.support.TestConstants.RESULTS_0_PATH;
+import static com.skapp.support.TestConstants.RESULTS_PATH;
+import static com.skapp.support.TestConstants.STATUS_PATH;
+import static com.skapp.support.TestConstants.STATUS_SUCCESSFUL;
+import static com.skapp.support.TestConstants.STATUS_UNSUCCESSFUL;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -43,55 +45,35 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest(classes = TestSkappApplication.class)
 @AutoConfigureMockMvc
+@Transactional
+@RequiredArgsConstructor
 @DisplayName("Job Controller Integration Tests")
 class JobControllerIntegrationTest {
 
 	private static final String BASE_PATH = "/v1/job";
 
-	private static final String STATUS_PATH = "['status']";
+	private final JsonMapper objectMapper;
 
-	private static final String RESULTS_PATH = "['results']";
+	private final AuthorityService authorityService;
 
-	private static final String RESULTS_0_PATH = "['results'][0]";
+	private final JwtService jwtService;
 
-	private static final String MESSAGE_PATH = "['message']";
+	private final UserDetailsService userDetailsService;
 
-	private static final String STATUS_SUCCESSFUL = "successful";
+	private final MockMvc mvc;
 
-	private static final String STATUS_UNSUCCESSFUL = "unsuccessful";
-
-	@Autowired
-	private JsonMapper objectMapper;
-
-	@Autowired
-	private AuthorityService authorityService;
-
-	@Autowired
-	private JwtService jwtService;
-
-	@Autowired
-	private UserDetailsService userDetailsService;
-
-	@Autowired
-	private MockMvc mvc;
+	private final MessageUtil messageUtil;
 
 	private String authToken;
 
 	@BeforeEach
 	void setup() {
-		setupSecurityContext();
+		SecurityTestUtils.setupSecurityContext(authorityService, MockUserFactory.createSuperAdminWithAllRoles());
 		authToken = jwtService.generateAccessToken(userDetailsService.loadUserByUsername("user1@gmail.com"), 1L);
 	}
 
-	private RequestPostProcessor bearerToken() {
-		return request -> {
-			request.addHeader("Authorization", "Bearer " + authToken);
-			return request;
-		};
-	}
-
 	private ResultActions performRequest(MockHttpServletRequestBuilder request) throws Exception {
-		return mvc.perform(request.with(bearerToken()));
+		return mvc.perform(request.with(SecurityTestUtils.bearerToken(authToken)));
 	}
 
 	private ResultActions performGetRequest(String path) throws Exception {
@@ -108,45 +90,6 @@ class JobControllerIntegrationTest {
 		return performRequest(patch(path).contentType(MediaType.APPLICATION_JSON)
 			.content(objectMapper.writeValueAsString(content))
 			.accept(MediaType.APPLICATION_JSON));
-	}
-
-	private void setupSecurityContext() {
-		User mockUser = createMockUser();
-		SkappUserDetails userDetails = SkappUserDetails.builder()
-			.username(mockUser.getEmail())
-			.password(mockUser.getPassword())
-			.enabled(mockUser.getIsActive())
-			.authorities(authorityService.getAuthorities(mockUser))
-			.build();
-
-		UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null,
-				userDetails.getAuthorities());
-
-		SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-		securityContext.setAuthentication(authentication);
-		SecurityContextHolder.setContext(securityContext);
-	}
-
-	private User createMockUser() {
-		User mockUser = new User();
-		mockUser.setEmail("user1@gmail.com");
-		mockUser.setPassword("$2a$12$CGe4n75Yejv/O8dnOTD7R.x0LruTiKM22kcdc3YNl4RRw01srJsB6");
-		mockUser.setIsActive(true);
-
-		Employee mockEmployee = new Employee();
-		mockEmployee.setEmployeeId(1L);
-		mockEmployee.setFirstName("name");
-
-		EmployeeRole role = new EmployeeRole();
-		role.setAttendanceRole(Role.SUPER_ADMIN);
-		role.setIsSuperAdmin(true);
-		role.setPeopleRole(Role.PEOPLE_ADMIN);
-		role.setLeaveRole(Role.LEAVE_ADMIN);
-		role.setAttendanceRole(Role.ATTENDANCE_ADMIN);
-
-		mockEmployee.setEmployeeRole(role);
-		mockUser.setEmployee(mockEmployee);
-		return mockUser;
 	}
 
 	@Nested
@@ -181,7 +124,8 @@ class JobControllerIntegrationTest {
 		void getJobFamilyWithNotExistingId_ReturnsNotFound() throws Exception {
 			performGetRequest(getFamilyPath("/12")).andExpect(status().isNotFound())
 				.andExpect(jsonPath(STATUS_PATH).value(STATUS_UNSUCCESSFUL))
-				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH).value("Job family isn't found"));
+				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH)
+					.value(messageUtil.getMessage(PeopleMessageConstant.PEOPLE_ERROR_JOB_FAMILY_NOT_FOUND)));
 		}
 
 		@Test
@@ -193,7 +137,8 @@ class JobControllerIntegrationTest {
 
 			performPostRequest(getFamilyPath(""), jobFamilyDto).andExpect(status().isBadRequest())
 				.andExpect(jsonPath(STATUS_PATH).value(STATUS_UNSUCCESSFUL))
-				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH).value("Insufficient data for job family"));
+				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH)
+					.value(messageUtil.getMessage(PeopleMessageConstant.PEOPLE_ERROR_JOB_FAMILY_INSUFFICIENT_DATA)));
 		}
 
 		@Test
@@ -216,8 +161,8 @@ class JobControllerIntegrationTest {
 
 			performPostRequest(getFamilyPath(""), jobFamilyDto).andExpect(status().isBadRequest())
 				.andExpect(jsonPath(STATUS_PATH).value(STATUS_UNSUCCESSFUL))
-				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH).value(
-						"Job family name & job title fields can only contain alphabets, numbers, whitespaces, and following symbols -_&/|[]"));
+				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH).value(messageUtil
+					.getMessage(PeopleMessageConstant.PEOPLE_ERROR_JOB_FAMILY_AND_JOB_TITLE_NAME_INVALID)));
 		}
 
 		@Test
@@ -271,7 +216,8 @@ class JobControllerIntegrationTest {
 
 			performPatchRequest(getTitlePath("/transfer/10"), transferDtos).andExpect(status().isNotFound())
 				.andExpect(jsonPath(STATUS_PATH).value(STATUS_UNSUCCESSFUL))
-				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH).value("Job title isn't found"));
+				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH)
+					.value(messageUtil.getMessage(PeopleMessageConstant.PEOPLE_ERROR_JOB_TITLE_NOT_FOUND)));
 		}
 
 		@Test
@@ -282,7 +228,7 @@ class JobControllerIntegrationTest {
 			performPatchRequest(getTitlePath("/transfer/5"), transferDtos).andExpect(status().isOk())
 				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
 				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH)
-					.value("Successfully transferred employees to another job title in the same job family"));
+					.value(messageUtil.getMessage(PeopleMessageConstant.PEOPLE_SUCCESS_TRANSFER_JOB_TITLE)));
 		}
 
 		@Test
@@ -292,8 +238,8 @@ class JobControllerIntegrationTest {
 
 			performPatchRequest(getTitlePath("/transfer/5"), transferDtos).andExpect(status().isBadRequest())
 				.andExpect(jsonPath(STATUS_PATH).value(STATUS_UNSUCCESSFUL))
-				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH)
-					.value("Job title and job family do not match or invalid job title"));
+				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH).value(
+						messageUtil.getMessage(PeopleMessageConstant.PEOPLE_ERROR_JOB_FAMILY_AND_JOB_TITLE_NOT_MATCH)));
 		}
 
 		@Test
@@ -304,7 +250,7 @@ class JobControllerIntegrationTest {
 			performPatchRequest(getTitlePath("/transfer/5"), transferDtos).andExpect(status().isNotFound())
 				.andExpect(jsonPath(STATUS_PATH).value(STATUS_UNSUCCESSFUL))
 				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH)
-					.value("No job title transfer data provided. Unable to process the transfer request."));
+					.value(messageUtil.getMessage(PeopleMessageConstant.PEOPLE_ERROR_JOB_TITLE_REQUEST_EMPTY)));
 		}
 
 		private List<TransferJobTitleRequestDto> createTransferRequestList(Long jobTitleId) {

--- a/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/JobControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/JobControllerIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.skapp.community.peopleplanner.controller.v1;
 
-import com.skapp.TestSkappApplication;
 import com.skapp.community.common.security.AuthorityService;
 import com.skapp.community.common.service.JwtService;
 import com.skapp.community.common.util.MessageUtil;
@@ -11,6 +10,7 @@ import com.skapp.community.peopleplanner.payload.request.TransferJobTitleRequest
 import com.skapp.community.peopleplanner.payload.request.UpdateJobFamilyRequestDto;
 import com.skapp.support.MockUserFactory;
 import com.skapp.support.SecurityTestUtils;
+import com.skapp.TestSkappApplication;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/PeopleControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/PeopleControllerIntegrationTest.java
@@ -8,6 +8,7 @@ import com.skapp.community.common.service.JwtService;
 import com.skapp.community.common.type.Role;
 import com.skapp.community.common.util.DateTimeUtils;
 import com.skapp.community.common.util.MessageUtil;
+import com.skapp.community.peopleplanner.constant.PeopleConstants;
 import com.skapp.community.peopleplanner.constant.PeopleMessageConstant;
 import com.skapp.community.peopleplanner.model.Employee;
 import com.skapp.community.peopleplanner.model.EmployeeRole;
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import com.skapp.TestSkappApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
@@ -44,7 +46,6 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import tools.jackson.databind.json.JsonMapper;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -54,7 +55,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@SpringBootTest(classes = TestSkappApplication.class)
 @AutoConfigureMockMvc
 @RequiredArgsConstructor
 @DisplayName("People Controller Integration Tests")
@@ -93,9 +94,9 @@ class PeopleControllerIntegrationTest {
 		employeeEmploymentBasicDetailsPrimaryManagerDetailsDto.setLastName("Primary Manager Name 2");
 
 		EmployeeEmploymentBasicDetailsManagerDetailsDto employeeEmploymentBasicDetailsSecondaryManagerDetailsDto = new EmployeeEmploymentBasicDetailsManagerDetailsDto();
-		employeeEmploymentBasicDetailsSecondaryManagerDetailsDto.setEmployeeId(1L);
-		employeeEmploymentBasicDetailsSecondaryManagerDetailsDto.setFirstName("Primary Manager Name 1");
-		employeeEmploymentBasicDetailsSecondaryManagerDetailsDto.setLastName("Primary Manager Name 2");
+		employeeEmploymentBasicDetailsSecondaryManagerDetailsDto.setEmployeeId(2L);
+		employeeEmploymentBasicDetailsSecondaryManagerDetailsDto.setFirstName("Secondary Manager Name 1");
+		employeeEmploymentBasicDetailsSecondaryManagerDetailsDto.setLastName("Secondary Manager Name 2");
 
 		employeeEmploymentBasicDetailsDto.setPrimarySupervisor(employeeEmploymentBasicDetailsPrimaryManagerDetailsDto);
 		List<EmployeeEmploymentBasicDetailsManagerDetailsDto> otherSupervisorsList = new ArrayList<>();
@@ -105,10 +106,12 @@ class PeopleControllerIntegrationTest {
 		Long[] teamIds = { 1L };
 		employeeEmploymentBasicDetailsDto.setTeamIds(teamIds);
 
-		employeeEmploymentBasicDetailsDto.setProbationStartDate(LocalDate.parse("2021-10-10"));
-		employeeEmploymentBasicDetailsDto.setProbationEndDate(LocalDate.parse("2021-12-28"));
 		employeeEmploymentBasicDetailsDto
 			.setJoinedDate(DateTimeUtils.getUtcLocalDate(DateTimeUtils.getCurrentYear() - 1, 1, 1));
+		employeeEmploymentBasicDetailsDto
+			.setProbationStartDate(DateTimeUtils.getUtcLocalDate(DateTimeUtils.getCurrentYear() - 1, 2, 1));
+		employeeEmploymentBasicDetailsDto
+			.setProbationEndDate(DateTimeUtils.getUtcLocalDate(DateTimeUtils.getCurrentYear() - 1, 4, 1));
 
 		employeeEmploymentBasicDetailsDto.setEmploymentAllocation(EmploymentAllocation.FULL_TIME);
 		return employeeEmploymentBasicDetailsDto;
@@ -230,6 +233,7 @@ class PeopleControllerIntegrationTest {
 		employeeSystemPermissionsDto.setLeaveRole(Role.LEAVE_EMPLOYEE);
 		employeeSystemPermissionsDto.setAttendanceRole(Role.ATTENDANCE_EMPLOYEE);
 		employeeSystemPermissionsDto.setPeopleRole(Role.PEOPLE_EMPLOYEE);
+		employeeSystemPermissionsDto.setInvoiceRole(Role.INVOICE_NONE);
 		employeeSystemPermissionsDto.setIsSuperAdmin(false);
 
 		EmployeeCommonDetailsDto employeeCommonDetailsDto = new EmployeeCommonDetailsDto();
@@ -271,11 +275,13 @@ class PeopleControllerIntegrationTest {
 		void addEmployee_WithInvalidLastName_ReturnsBadRequest() throws Exception {
 
 			CreateEmployeeRequestDto createEmployeeRequestDto = createEmployeeDetails();
+			createEmployeeRequestDto.getEmployment().getEmploymentDetails().setEmail("lastname-test@gmail.com");
 			EmployeePersonalDetailsDto employeePersonalDetailsDto = new EmployeePersonalDetailsDto();
 
 			EmployeePersonalGeneralDetailsDto employeePersonalGeneralDetailsDto = new EmployeePersonalGeneralDetailsDto();
 			employeePersonalGeneralDetailsDto.setFirstName("first name");
-			employeePersonalGeneralDetailsDto.setLastName("last name 456");
+			employeePersonalGeneralDetailsDto
+				.setLastName("this is a very long last name that exceeds the maximum allowed length");
 
 			employeePersonalDetailsDto.setGeneral(employeePersonalGeneralDetailsDto);
 			createEmployeeRequestDto.setPersonal(employeePersonalDetailsDto);
@@ -284,17 +290,20 @@ class PeopleControllerIntegrationTest {
 				.andExpect(status().isBadRequest())
 				.andExpect(jsonPath(STATUS_PATH).value(STATUS_UNSUCCESSFUL))
 				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH)
-					.value(messageUtil.getMessage(CommonMessageConstant.COMMON_ERROR_VALIDATION_LAST_NAME)));
+					.value(messageUtil.getMessage(CommonMessageConstant.COMMON_ERROR_VALIDATION_LAST_NAME_LENGTH,
+							new Object[] { PeopleConstants.MAX_NAME_LENGTH })));
 		}
 
 		@Test
 		@DisplayName("Add employee with invalid first name - Returns Bad Request")
 		void addEmployee_WithInvalidFirstName_ReturnsBadRequest() throws Exception {
 			CreateEmployeeRequestDto createEmployeeRequestDto = createEmployeeDetails();
+			createEmployeeRequestDto.getEmployment().getEmploymentDetails().setEmail("firstname-test@gmail.com");
 			EmployeePersonalDetailsDto employeePersonalDetailsDto = new EmployeePersonalDetailsDto();
 
 			EmployeePersonalGeneralDetailsDto employeePersonalGeneralDetailsDto = new EmployeePersonalGeneralDetailsDto();
-			employeePersonalGeneralDetailsDto.setFirstName("first name 123");
+			employeePersonalGeneralDetailsDto
+				.setFirstName("this is a very long first name that exceeds the maximum allowed length");
 			employeePersonalGeneralDetailsDto.setLastName("last name");
 
 			employeePersonalDetailsDto.setGeneral(employeePersonalGeneralDetailsDto);
@@ -304,7 +313,8 @@ class PeopleControllerIntegrationTest {
 				.andExpect(status().isBadRequest())
 				.andExpect(jsonPath(STATUS_PATH).value(STATUS_UNSUCCESSFUL))
 				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH)
-					.value(messageUtil.getMessage(CommonMessageConstant.COMMON_ERROR_VALIDATION_FIRST_NAME)));
+					.value(messageUtil.getMessage(CommonMessageConstant.COMMON_ERROR_VALIDATION_FIRST_NAME_LENGTH,
+							new Object[] { PeopleConstants.MAX_NAME_LENGTH })));
 		}
 
 	}

--- a/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/PeopleControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/PeopleControllerIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.skapp.community.peopleplanner.controller.v1;
 
-import com.skapp.TestSkappApplication;
 import com.skapp.community.common.constant.CommonMessageConstant;
 import com.skapp.community.common.security.AuthorityService;
 import com.skapp.community.common.service.JwtService;
@@ -26,6 +25,7 @@ import com.skapp.community.peopleplanner.type.EmploymentAllocation;
 import com.skapp.community.peopleplanner.type.Gender;
 import com.skapp.support.MockUserFactory;
 import com.skapp.support.SecurityTestUtils;
+import com.skapp.TestSkappApplication;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/PeopleControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/PeopleControllerIntegrationTest.java
@@ -1,17 +1,14 @@
 package com.skapp.community.peopleplanner.controller.v1;
 
+import com.skapp.TestSkappApplication;
 import com.skapp.community.common.constant.CommonMessageConstant;
-import com.skapp.community.common.model.User;
 import com.skapp.community.common.security.AuthorityService;
-import com.skapp.community.common.security.SkappUserDetails;
 import com.skapp.community.common.service.JwtService;
 import com.skapp.community.common.type.Role;
 import com.skapp.community.common.util.DateTimeUtils;
 import com.skapp.community.common.util.MessageUtil;
 import com.skapp.community.peopleplanner.constant.PeopleConstants;
 import com.skapp.community.peopleplanner.constant.PeopleMessageConstant;
-import com.skapp.community.peopleplanner.model.Employee;
-import com.skapp.community.peopleplanner.model.EmployeeRole;
 import com.skapp.community.peopleplanner.payload.request.EmployeeUpdateDto;
 import com.skapp.community.peopleplanner.payload.request.employee.CreateEmployeeRequestDto;
 import com.skapp.community.peopleplanner.payload.request.employee.EmployeeCommonDetailsDto;
@@ -27,28 +24,30 @@ import com.skapp.community.peopleplanner.type.AccountStatus;
 import com.skapp.community.peopleplanner.type.EEO;
 import com.skapp.community.peopleplanner.type.EmploymentAllocation;
 import com.skapp.community.peopleplanner.type.Gender;
+import com.skapp.support.MockUserFactory;
+import com.skapp.support.SecurityTestUtils;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import com.skapp.TestSkappApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.skapp.support.TestConstants.MESSAGE_PATH;
+import static com.skapp.support.TestConstants.RESULTS_0_PATH;
+import static com.skapp.support.TestConstants.STATUS_PATH;
+import static com.skapp.support.TestConstants.STATUS_UNSUCCESSFUL;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -57,17 +56,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest(classes = TestSkappApplication.class)
 @AutoConfigureMockMvc
+@Transactional
 @RequiredArgsConstructor
 @DisplayName("People Controller Integration Tests")
 class PeopleControllerIntegrationTest {
-
-	private static final String STATUS_PATH = "['status']";
-
-	private static final String RESULTS_0_PATH = "['results'][0]";
-
-	private static final String MESSAGE_PATH = "['message']";
-
-	private static final String STATUS_UNSUCCESSFUL = "unsuccessful";
 
 	private final JsonMapper objectMapper;
 
@@ -131,19 +123,12 @@ class PeopleControllerIntegrationTest {
 
 	@BeforeEach
 	void setup() {
-		setupSecurityContext();
+		SecurityTestUtils.setupSecurityContext(authorityService, MockUserFactory.createSuperAdminWithAllRoles());
 		authToken = jwtService.generateAccessToken(userDetailsService.loadUserByUsername("user1@gmail.com"), 1L);
 	}
 
-	private RequestPostProcessor bearerToken() {
-		return request -> {
-			request.addHeader("Authorization", "Bearer " + authToken);
-			return request;
-		};
-	}
-
 	private ResultActions performRequest(MockHttpServletRequestBuilder request) throws Exception {
-		return mvc.perform(request.with(bearerToken()));
+		return mvc.perform(request.with(SecurityTestUtils.bearerToken(authToken)));
 	}
 
 	private <T> ResultActions performPostRequest(T content) throws Exception {
@@ -156,45 +141,6 @@ class PeopleControllerIntegrationTest {
 		return performRequest(patch("/v1/people/employee/100").contentType(MediaType.APPLICATION_JSON)
 			.content(objectMapper.writeValueAsString(content))
 			.accept(MediaType.APPLICATION_JSON));
-	}
-
-	private void setupSecurityContext() {
-		User mockUser = createMockUser();
-		SkappUserDetails userDetails = SkappUserDetails.builder()
-			.username(mockUser.getEmail())
-			.password(mockUser.getPassword())
-			.enabled(mockUser.getIsActive())
-			.authorities(authorityService.getAuthorities(mockUser))
-			.build();
-
-		UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null,
-				userDetails.getAuthorities());
-
-		SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-		securityContext.setAuthentication(authentication);
-		SecurityContextHolder.setContext(securityContext);
-	}
-
-	private User createMockUser() {
-		User mockUser = new User();
-		mockUser.setEmail("user1@gmail.com");
-		mockUser.setPassword("$2a$12$CGe4n75Yejv/O8dnOTD7R.x0LruTiKM22kcdc3YNl4RRw01srJsB6");
-		mockUser.setIsActive(true);
-
-		Employee mockEmployee = new Employee();
-		mockEmployee.setEmployeeId(1L);
-		mockEmployee.setFirstName("name");
-
-		EmployeeRole role = new EmployeeRole();
-		role.setAttendanceRole(Role.ATTENDANCE_ADMIN);
-		role.setPeopleRole(Role.PEOPLE_ADMIN);
-		role.setLeaveRole(Role.LEAVE_ADMIN);
-		role.setIsSuperAdmin(true);
-
-		mockEmployee.setEmployeeRole(role);
-		mockUser.setEmployee(mockEmployee);
-
-		return mockUser;
 	}
 
 	private CreateEmployeeRequestDto createEmployeeDetails() {

--- a/backend/src/test/java/com/skapp/community/peopleplanner/service/JobServiceImplUnitTest.java
+++ b/backend/src/test/java/com/skapp/community/peopleplanner/service/JobServiceImplUnitTest.java
@@ -13,10 +13,10 @@ import com.skapp.community.peopleplanner.service.impl.JobServiceImpl;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.HashSet;
 import java.util.Optional;
@@ -24,8 +24,7 @@ import java.util.Set;
 
 import static org.mockito.Mockito.when;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+@ExtendWith(MockitoExtension.class)
 class JobServiceImplUnitTest {
 
 	JobServiceImpl jobService;

--- a/backend/src/test/java/com/skapp/community/timeplanner/controller/v1/TimeControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/timeplanner/controller/v1/TimeControllerIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.skapp.community.timeplanner.controller.v1;
 
-import com.skapp.TestSkappApplication;
 import com.skapp.community.common.security.AuthorityService;
 import com.skapp.community.common.service.JwtService;
 import com.skapp.community.common.util.DateTimeUtils;
@@ -14,6 +13,7 @@ import com.skapp.community.timeplanner.payload.request.TimeRequestManagerPatchDt
 import com.skapp.community.timeplanner.type.TimeRecordActionTypes;
 import com.skapp.support.MockUserFactory;
 import com.skapp.support.SecurityTestUtils;
+import com.skapp.TestSkappApplication;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/backend/src/test/java/com/skapp/community/timeplanner/controller/v1/TimeControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/timeplanner/controller/v1/TimeControllerIntegrationTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import com.skapp.TestSkappApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
@@ -52,7 +53,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
+@SpringBootTest(classes = TestSkappApplication.class)
 @AutoConfigureMockMvc
 @RequiredArgsConstructor
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -313,8 +314,8 @@ class TimeControllerIntegrationTest {
 		@Test
 		@DisplayName("Add manual entry without request type - Returns Created")
 		void addManualEntryRequest_WithoutRequestType_ReturnsCreated() throws Exception {
-			LocalDateTime startTime = LocalDateTime.of(DateTimeUtils.getCurrentYear(), 2, 27, 5, 30, 0);
-			LocalDateTime endTime = LocalDateTime.of(DateTimeUtils.getCurrentYear(), 2, 27, 6, 30, 0);
+			LocalDateTime startTime = LocalDateTime.of(2025, 2, 27, 5, 30, 0);
+			LocalDateTime endTime = LocalDateTime.of(2025, 2, 27, 6, 30, 0);
 
 			ManualEntryRequestDto manualEntryRequestDto = new ManualEntryRequestDto();
 			manualEntryRequestDto.setStartTime(startTime);

--- a/backend/src/test/java/com/skapp/community/timeplanner/controller/v1/TimeControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/timeplanner/controller/v1/TimeControllerIntegrationTest.java
@@ -1,51 +1,45 @@
 package com.skapp.community.timeplanner.controller.v1;
 
-import com.skapp.community.common.model.User;
+import com.skapp.TestSkappApplication;
 import com.skapp.community.common.security.AuthorityService;
-import com.skapp.community.common.security.SkappUserDetails;
 import com.skapp.community.common.service.JwtService;
-import com.skapp.community.common.type.Role;
 import com.skapp.community.common.util.DateTimeUtils;
-import com.skapp.community.peopleplanner.model.Employee;
-import com.skapp.community.peopleplanner.model.EmployeeManager;
-import com.skapp.community.peopleplanner.model.EmployeeRole;
-import com.skapp.community.peopleplanner.type.AccountStatus;
-import com.skapp.community.peopleplanner.type.EmploymentAllocation;
+import com.skapp.community.common.util.MessageUtil;
+import com.skapp.community.timeplanner.constant.TimeMessageConstant;
 import com.skapp.community.peopleplanner.type.RequestStatus;
 import com.skapp.community.peopleplanner.type.RequestType;
 import com.skapp.community.timeplanner.payload.request.AddTimeRecordDto;
 import com.skapp.community.timeplanner.payload.request.ManualEntryRequestDto;
 import com.skapp.community.timeplanner.payload.request.TimeRequestManagerPatchDto;
 import com.skapp.community.timeplanner.type.TimeRecordActionTypes;
+import com.skapp.support.MockUserFactory;
+import com.skapp.support.SecurityTestUtils;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
-import com.skapp.TestSkappApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.HashSet;
-import java.util.Set;
 
+import static com.skapp.support.TestConstants.MESSAGE_PATH;
+import static com.skapp.support.TestConstants.RESULTS_0_PATH;
+import static com.skapp.support.TestConstants.RESULTS_PATH;
+import static com.skapp.support.TestConstants.STATUS_PATH;
+import static com.skapp.support.TestConstants.STATUS_SUCCESSFUL;
+import static com.skapp.support.TestConstants.STATUS_UNSUCCESSFUL;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -55,24 +49,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @SpringBootTest(classes = TestSkappApplication.class)
 @AutoConfigureMockMvc
+@Transactional
 @RequiredArgsConstructor
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @DisplayName("Time Controller Integration Tests")
 class TimeControllerIntegrationTest {
 
 	private static final String BASE_PATH = "/v1/time";
-
-	private static final String STATUS_PATH = "['status']";
-
-	private static final String RESULTS_PATH = "['results']";
-
-	private static final String RESULTS_0_PATH = "['results'][0]";
-
-	private static final String MESSAGE_PATH = "['message']";
-
-	private static final String STATUS_SUCCESSFUL = "successful";
-
-	private static final String STATUS_UNSUCCESSFUL = "unsuccessful";
 
 	private final AuthorityService authorityService;
 
@@ -84,23 +66,18 @@ class TimeControllerIntegrationTest {
 
 	private final MockMvc mvc;
 
+	private final MessageUtil messageUtil;
+
 	private String authToken;
 
 	@BeforeEach
 	void setup() {
-		setupSecurityContext();
+		SecurityTestUtils.setupSecurityContext(authorityService, MockUserFactory.createSuperAdminWithManager());
 		authToken = jwtService.generateAccessToken(userDetailsService.loadUserByUsername("user1@gmail.com"), 1L);
 	}
 
-	private RequestPostProcessor bearerToken() {
-		return request -> {
-			request.addHeader("Authorization", "Bearer " + authToken);
-			return request;
-		};
-	}
-
 	private ResultActions performRequest(MockHttpServletRequestBuilder request) throws Exception {
-		return mvc.perform(request.with(bearerToken()));
+		return mvc.perform(request.with(SecurityTestUtils.bearerToken(authToken)));
 	}
 
 	private ResultActions performGetRequest() throws Exception {
@@ -124,81 +101,11 @@ class TimeControllerIntegrationTest {
 			.accept(MediaType.APPLICATION_JSON));
 	}
 
-	private void setupSecurityContext() {
-		User mockUser = createMockUser();
-		SkappUserDetails userDetails = SkappUserDetails.builder()
-			.username(mockUser.getEmail())
-			.password(mockUser.getPassword())
-			.enabled(mockUser.getIsActive())
-			.authorities(authorityService.getAuthorities(mockUser))
-			.build();
-
-		UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null,
-				userDetails.getAuthorities());
-
-		SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-		securityContext.setAuthentication(authentication);
-		SecurityContextHolder.setContext(securityContext);
-	}
-
-	private User createMockUser() {
-		// Create main user
-		User mockUser = new User();
-		mockUser.setEmail("user1@gmail.com");
-		mockUser.setPassword("$2a$12$CGe4n75Yejv/O8dnOTD7R.x0LruTiKM22kcdc3YNl4RRw01srJsB6");
-		mockUser.setUserId(1L);
-		mockUser.setIsActive(true);
-
-		// Create manager user
-		User mockManagerUser = new User();
-		mockManagerUser.setEmail("user2@gmail.com");
-		mockManagerUser.setPassword("$2a$12$Z6/UrecHPvvCBVj/kEeGWezwhMzg46fPSJiAr/sLnBxhDAZfF4/1W");
-		mockManagerUser.setUserId(2L);
-		mockManagerUser.setIsActive(true);
-
-		// Create employee
-		Employee mockEmployee = new Employee();
-		mockEmployee.setEmployeeId(1L);
-		mockEmployee.setFirstName("name");
-		mockEmployee.setAccountStatus(AccountStatus.ACTIVE);
-		mockEmployee.setEmploymentAllocation(EmploymentAllocation.FULL_TIME);
-
-		// Create manager employee
-		Employee managerEmployee = new Employee();
-		managerEmployee.setEmployeeId(2L);
-		managerEmployee.setFirstName("name");
-		managerEmployee.setAccountStatus(AccountStatus.ACTIVE);
-		managerEmployee.setEmploymentAllocation(EmploymentAllocation.FULL_TIME);
-		managerEmployee.setUser(mockManagerUser);
-
-		// Set up employee-manager relationship
-		EmployeeManager employeeManager = new EmployeeManager();
-		employeeManager.setEmployee(mockEmployee);
-		employeeManager.setManager(managerEmployee);
-		Set<EmployeeManager> managerSet = new HashSet<>();
-		managerSet.add(employeeManager);
-		mockEmployee.setEmployeeManagers(managerSet);
-
-		// Set up employee role
-		EmployeeRole role = new EmployeeRole();
-		role.setEmployeeRoleId(1L);
-		role.setAttendanceRole(Role.SUPER_ADMIN);
-		role.setIsSuperAdmin(true);
-		mockEmployee.setEmployeeRole(role);
-
-		// Connect user and employee
-		mockUser.setEmployee(mockEmployee);
-		mockEmployee.setUser(mockUser);
-
-		return mockUser;
-	}
-
 	@Nested
 	@DisplayName("Time Slot Tests")
 	class TimeSlotTests {
 
 		@Test
-		@Order(1)
 		@DisplayName("Get active time slot when clocked out - Returns OK")
 		void getActiveTimeSlotWhenTimeRecordAvailable_ButClockedOut_ReturnsHttpStatusOk() throws Exception {
 			performGetRequest().andDo(print())
@@ -208,7 +115,6 @@ class TimeControllerIntegrationTest {
 		}
 
 		@Test
-		@Order(2)
 		@DisplayName("Get active time slot - Returns OK")
 		void getActiveTimeSlot_ReturnsOk() throws Exception {
 			performGetRequest().andDo(print())
@@ -224,7 +130,6 @@ class TimeControllerIntegrationTest {
 	class TimeRecordTests {
 
 		@Test
-		@Order(3)
 		@DisplayName("Add time log for current day with CLOCK_IN - Returns OK")
 		void addTimeLog_ForTheCurrentDay_CLOCK_IN_ReturnsHttpStatusOk() throws Exception {
 			LocalDateTime startTime = DateTimeUtils.getCurrentUtcDateTime().minusDays(1L);
@@ -235,7 +140,8 @@ class TimeControllerIntegrationTest {
 			performPostRequest(BASE_PATH + "/record", addTimeRecordDto).andDo(print())
 				.andExpect(status().isOk())
 				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
-				.andExpect(jsonPath(RESULTS_0_PATH).value("Time Record Added Successfully " + startTime + " START"));
+				.andExpect(jsonPath(RESULTS_0_PATH).value(messageUtil.getMessage(
+						TimeMessageConstant.TIME_SUCCESS_TIME_RECORD_ADDED, new Object[] { startTime, "START" })));
 		}
 
 		@Test
@@ -248,8 +154,8 @@ class TimeControllerIntegrationTest {
 			performPostRequest(BASE_PATH + "/record", addTimeRecordDto).andDo(print())
 				.andExpect(status().isBadRequest())
 				.andExpect(jsonPath(STATUS_PATH).value(STATUS_UNSUCCESSFUL))
-				.andExpect(
-						jsonPath(RESULTS_0_PATH + MESSAGE_PATH).value("Clock in already exists for the current date"));
+				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH).value(
+						messageUtil.getMessage(TimeMessageConstant.TIME_ERROR_TIME_CLOCK_IN_EXISTS_FOR_CURRENT_DATE)));
 		}
 
 		@Test
@@ -262,8 +168,8 @@ class TimeControllerIntegrationTest {
 			performPostRequest(BASE_PATH + "/record", addTimeRecordDto).andDo(print())
 				.andExpect(status().isBadRequest())
 				.andExpect(jsonPath(STATUS_PATH).value(STATUS_UNSUCCESSFUL))
-				.andExpect(
-						jsonPath(RESULTS_0_PATH + MESSAGE_PATH).value("Clock in does not exists for the current date"));
+				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH).value(
+						messageUtil.getMessage(TimeMessageConstant.TIME_ERROR_CLOCK_IN_NOT_EXISTS_FOR_CURRENT_DATE)));
 		}
 
 	}
@@ -288,7 +194,8 @@ class TimeControllerIntegrationTest {
 			performPostRequest(BASE_PATH + "/manual-entry", manualEntryRequestDto).andDo(print())
 				.andExpect(status().isBadRequest())
 				.andExpect(jsonPath(STATUS_PATH).value(STATUS_UNSUCCESSFUL))
-				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH).value("Start time cannot be after end time"));
+				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH)
+					.value(messageUtil.getMessage(TimeMessageConstant.TIME_ERROR_END_TIME_BEFORE_START_TIME)));
 		}
 
 		@Test
@@ -308,7 +215,7 @@ class TimeControllerIntegrationTest {
 				.andExpect(status().isBadRequest())
 				.andExpect(jsonPath(STATUS_PATH).value(STATUS_UNSUCCESSFUL))
 				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH)
-					.value("Start time and End time must be within the same day"));
+					.value(messageUtil.getMessage(TimeMessageConstant.TIME_ERROR_START_END_TIME_DIFFERENT_DATES)));
 		}
 
 		@Test
@@ -377,7 +284,8 @@ class TimeControllerIntegrationTest {
 
 			performGetRequestWithParams(queryParams).andDo(print())
 				.andExpect(status().isBadRequest())
-				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH).value("Start date and end date are not valid"));
+				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH)
+					.value(messageUtil.getMessage(TimeMessageConstant.TIME_ERROR_START_DATE_END_DATE_NOT_VALID)));
 		}
 
 	}

--- a/backend/src/test/java/com/skapp/support/MockUserFactory.java
+++ b/backend/src/test/java/com/skapp/support/MockUserFactory.java
@@ -1,0 +1,147 @@
+package com.skapp.support;
+
+import com.skapp.community.common.model.User;
+import com.skapp.community.common.type.Role;
+import com.skapp.community.peopleplanner.model.Employee;
+import com.skapp.community.peopleplanner.model.EmployeeManager;
+import com.skapp.community.peopleplanner.model.EmployeeRole;
+import com.skapp.community.peopleplanner.type.AccountStatus;
+import com.skapp.community.peopleplanner.type.EmploymentAllocation;
+import lombok.experimental.UtilityClass;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@UtilityClass
+public class MockUserFactory {
+
+	private static final String DEFAULT_PASSWORD = "$2a$12$CGe4n75Yejv/O8dnOTD7R.x0LruTiKM22kcdc3YNl4RRw01srJsB6";
+
+	/**
+	 * Creates a basic super admin user (user1). Used by Holiday, Organization tests.
+	 */
+	public static User createSuperAdmin() {
+		User mockUser = createBaseUser("user1@gmail.com", 1L);
+
+		Employee mockEmployee = createBaseEmployee(1L);
+		EmployeeRole role = new EmployeeRole();
+		role.setAttendanceRole(Role.SUPER_ADMIN);
+		role.setIsSuperAdmin(true);
+		mockEmployee.setEmployeeRole(role);
+
+		linkUserAndEmployee(mockUser, mockEmployee);
+		return mockUser;
+	}
+
+	/**
+	 * Creates a super admin with all module roles. Used by People, Job tests.
+	 */
+	public static User createSuperAdminWithAllRoles() {
+		User mockUser = createBaseUser("user1@gmail.com", 1L);
+
+		Employee mockEmployee = createBaseEmployee(1L);
+		EmployeeRole role = new EmployeeRole();
+		role.setAttendanceRole(Role.ATTENDANCE_ADMIN);
+		role.setPeopleRole(Role.PEOPLE_ADMIN);
+		role.setLeaveRole(Role.LEAVE_ADMIN);
+		role.setIsSuperAdmin(true);
+		mockEmployee.setEmployeeRole(role);
+
+		linkUserAndEmployee(mockUser, mockEmployee);
+		return mockUser;
+	}
+
+	/**
+	 * Creates a super admin with manager relationship. Used by Time tests.
+	 */
+	public static User createSuperAdminWithManager() {
+		User mockUser = createBaseUser("user1@gmail.com", 1L);
+
+		User mockManagerUser = new User();
+		mockManagerUser.setEmail("user2@gmail.com");
+		mockManagerUser.setPassword("$2a$12$Z6/UrecHPvvCBVj/kEeGWezwhMzg46fPSJiAr/sLnBxhDAZfF4/1W");
+		mockManagerUser.setUserId(2L);
+		mockManagerUser.setIsActive(true);
+
+		Employee mockEmployee = createBaseEmployee(1L);
+		mockEmployee.setAccountStatus(AccountStatus.ACTIVE);
+		mockEmployee.setEmploymentAllocation(EmploymentAllocation.FULL_TIME);
+
+		Employee managerEmployee = new Employee();
+		managerEmployee.setEmployeeId(2L);
+		managerEmployee.setFirstName("name");
+		managerEmployee.setAccountStatus(AccountStatus.ACTIVE);
+		managerEmployee.setEmploymentAllocation(EmploymentAllocation.FULL_TIME);
+		managerEmployee.setUser(mockManagerUser);
+
+		EmployeeManager employeeManager = new EmployeeManager();
+		employeeManager.setEmployee(mockEmployee);
+		employeeManager.setManager(managerEmployee);
+		Set<EmployeeManager> managerSet = new HashSet<>();
+		managerSet.add(employeeManager);
+		mockEmployee.setEmployeeManagers(managerSet);
+
+		EmployeeRole role = new EmployeeRole();
+		role.setEmployeeRoleId(1L);
+		role.setAttendanceRole(Role.SUPER_ADMIN);
+		role.setIsSuperAdmin(true);
+		mockEmployee.setEmployeeRole(role);
+
+		linkUserAndEmployee(mockUser, mockEmployee);
+		return mockUser;
+	}
+
+	/**
+	 * Creates a leave employee user (user2). Used by Leave Controller tests.
+	 */
+	public static User createLeaveEmployee() {
+		User mockUser = createBaseUser("user2@gmail.com", 2L);
+
+		Employee mockEmployee = createBaseEmployee(2L);
+		EmployeeRole role = new EmployeeRole();
+		role.setLeaveRole(Role.LEAVE_EMPLOYEE);
+		role.setIsSuperAdmin(true);
+		mockEmployee.setEmployeeRole(role);
+
+		linkUserAndEmployee(mockUser, mockEmployee);
+		return mockUser;
+	}
+
+	/**
+	 * Creates a leave admin user (user1). Used by Leave Analytics tests.
+	 */
+	public static User createLeaveAdmin() {
+		User mockUser = createBaseUser("user1@gmail.com", 1L);
+
+		Employee mockEmployee = createBaseEmployee(1L);
+		EmployeeRole role = new EmployeeRole();
+		role.setLeaveRole(Role.LEAVE_ADMIN);
+		role.setIsSuperAdmin(true);
+		mockEmployee.setEmployeeRole(role);
+
+		linkUserAndEmployee(mockUser, mockEmployee);
+		return mockUser;
+	}
+
+	private static User createBaseUser(String email, Long userId) {
+		User user = new User();
+		user.setEmail(email);
+		user.setPassword(DEFAULT_PASSWORD);
+		user.setUserId(userId);
+		user.setIsActive(true);
+		return user;
+	}
+
+	private static Employee createBaseEmployee(Long employeeId) {
+		Employee employee = new Employee();
+		employee.setEmployeeId(employeeId);
+		employee.setFirstName("name");
+		return employee;
+	}
+
+	private static void linkUserAndEmployee(User user, Employee employee) {
+		user.setEmployee(employee);
+		employee.setUser(user);
+	}
+
+}

--- a/backend/src/test/java/com/skapp/support/SecurityTestUtils.java
+++ b/backend/src/test/java/com/skapp/support/SecurityTestUtils.java
@@ -1,0 +1,38 @@
+package com.skapp.support;
+
+import com.skapp.community.common.model.User;
+import com.skapp.community.common.security.AuthorityService;
+import com.skapp.community.common.security.SkappUserDetails;
+import lombok.experimental.UtilityClass;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+@UtilityClass
+public class SecurityTestUtils {
+
+	public static void setupSecurityContext(AuthorityService authorityService, User mockUser) {
+		SkappUserDetails userDetails = SkappUserDetails.builder()
+			.username(mockUser.getEmail())
+			.password(mockUser.getPassword())
+			.enabled(mockUser.getIsActive())
+			.authorities(authorityService.getAuthorities(mockUser))
+			.build();
+
+		UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null,
+				userDetails.getAuthorities());
+
+		SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+		securityContext.setAuthentication(authentication);
+		SecurityContextHolder.setContext(securityContext);
+	}
+
+	public static RequestPostProcessor bearerToken(String authToken) {
+		return request -> {
+			request.addHeader("Authorization", "Bearer " + authToken);
+			return request;
+		};
+	}
+
+}

--- a/backend/src/test/java/com/skapp/support/TestConstants.java
+++ b/backend/src/test/java/com/skapp/support/TestConstants.java
@@ -1,0 +1,20 @@
+package com.skapp.support;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class TestConstants {
+
+	public static final String STATUS_PATH = "['status']";
+
+	public static final String RESULTS_PATH = "['results']";
+
+	public static final String RESULTS_0_PATH = "['results'][0]";
+
+	public static final String MESSAGE_PATH = "['message']";
+
+	public static final String STATUS_SUCCESSFUL = "successful";
+
+	public static final String STATUS_UNSUCCESSFUL = "unsuccessful";
+
+}

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -4,12 +4,8 @@ spring:
   profiles:
     active: test
   datasource:
-    master:
-      write:
-        url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
-      read:
-        url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
-    driverClassName: org.h2.Driver
+    url: jdbc:h2:mem:test;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
     username: sa
     password:
 
@@ -64,3 +60,6 @@ encryptDecryptAlgorithm:
 
 app:
   version: 1.0
+
+domain:
+  base: localhost

--- a/backend/src/test/resources/spring.properties
+++ b/backend/src/test/resources/spring.properties
@@ -1,0 +1,1 @@
+spring.test.constructor.autowire.mode=all


### PR DESCRIPTION
## What does this PR do?
Fixes all 62 community test cases that were failing due to enterprise multi-tenant beans loading during test context initialization, and corrects several pre-existing test data issues.

## Changes

### `TestSkappApplication` (NEW)
- Test-specific Spring Boot application class that scans only `com.skapp.community` packages
- Explicit `@EnableJpaRepositories` and `@EntityScan` restricted to community modules
- Prevents enterprise multi-tenant configuration (TenantRoutingDataSource, MultiTenantJpaConfig, etc.) from loading during tests

### `application.yml` (test resources)
- Changed from multi-tenant datasource config (`spring.datasource.master.write.url`/`read.url`) to standard single H2 datasource (`spring.datasource.url`)
- Added missing `domain.base: localhost` property required by CookieUtil

### `spring.properties` (NEW - test resources)
- Enables `spring.test.constructor.autowire.mode=all` for tests using `@RequiredArgsConstructor` constructor injection

### All Integration Tests (10 files)
- Updated `@SpringBootTest` to `@SpringBootTest(classes = TestSkappApplication.class)` to use community-only test context

### `JobServiceImplUnitTest`
- Changed from `@SpringBootTest` to `@ExtendWith(MockitoExtension.class)` — pure unit test with mocks doesn't need Spring context

### `PeopleControllerIntegrationTest`
- Fixed secondary supervisor `employeeId` from `1L` to `2L` (was duplicating primary supervisor, triggering wrong validation)
- Fixed probation dates to be relative to joined date (were hardcoded to 2021, before the dynamic joined date)
- Added `invoiceRole(Role.INVOICE_NONE)` to system permissions (required by role validation)
- Updated name validation tests to test actual length validation (>50 chars) instead of non-existent character regex validation
- Added unique emails per test to prevent cross-test interference

### `TimeControllerIntegrationTest`
- Fixed manual entry test date to use `2025` matching `data.sql` record date (was using `getCurrentYear()` = 2026, causing date mismatch)

### `people-messages.properties`
- Added missing message key: `api.error.people.invoice-role-required=Invoice role is required`

## Testing
- [x] Verified compilation clean (`mvn compile`)
- [x] Formatting applied (`mvn spring-javaformat:apply`)
- [x] All 62 tests pass: `Tests run: 62, Failures: 0, Errors: 0, Skipped: 0`
