### PR TITLE
fix: sort working days when adding a new day

### DIFF
--- a/frontend/src/community/configurations/components/organisms/TimeConfigurations/TimeConfigurations.tsx
+++ b/frontend/src/community/configurations/components/organisms/TimeConfigurations/TimeConfigurations.tsx
@@ -123,7 +123,10 @@ const TimeConfigurations = (): JSX.Element => {
       );
       setWorkingDays(updatedSettings);
     } else {
-      setWorkingDays([...workingDays, { id: index, day }]);
+      const updatedSettings = [...workingDays, { id: index, day }].sort(
+        (a, b) => a.id - b.id
+      );
+      setWorkingDays(updatedSettings);
     }
     setWeekStartDay("");
   };


### PR DESCRIPTION
## 1. Timestamp

Date Identified: 2025/11/19

---

## 2. Bug Description

Tested Environment: Enterprise - Core - DEV

Summary:

> When a week day is removed from the standard work days and then re-added, it appears at the bottom of the start week dropdown list instead of its correct chronological position.

Pre Conditions:

- User is logged in as a super admin.

Steps to Reproduce:

1. Navigate to time configurations section via the nav bar.

2. Remove a day from the standard work days.

3. Re-select the same day.

4. Observe the position of the newly re-added day in the start of the week dropdown.

Actual Result:

> The re-added day appears at the bottom of the dropdown, rather than in chronological order.

Expected Result:

> The dropdown should display all days in the correct chronological order, regardless of add/remove actions.

Screenshots / Logs / Trace (if any):



---

## 3. Impact Assessment

Affected Users or Systems:

> All admin users managing time configurations.

Severity Level:

- [ ] Critical – Major failure or crash

- [ ] Major – Key functionality impacted

- [x] Minor – Non-blocking issue

How Was It Detected?

- [x] Feature Testing

- [ ] Smoke Testing

- [ ] Regression Testing

- [ ] Customer