### PR TITLE
fix: update CustomLeaveAllocationForm to clear fields on employee sea…

### DIFF
--- a/frontend/src/community/common/components/molecules/AutocompleteSearch/EmployeeAutocompleteSearch.tsx
+++ b/frontend/src/community/common/components/molecules/AutocompleteSearch/EmployeeAutocompleteSearch.tsx
@@ -8,14 +8,16 @@ import {
   useTheme
 } from "@mui/material";
 import Autocomplete, {
+  AutocompleteInputChangeReason,
   AutocompleteRenderInputParams
 } from "@mui/material/Autocomplete";
 import { useMemo } from "react";
 
+import { ZIndexEnums } from "~community/common/enums/CommonEnums";
 import { IconName } from "~community/common/types/IconTypes";
 import { mergeSx } from "~community/common/utils/commonUtil";
 import { EmployeeType } from "~community/people/types/EmployeeTypes";
-import { ZIndexEnums } from "~community/common/enums/CommonEnums";
+
 import Icon from "../../atoms/Icon/Icon";
 import AvatarChip from "../AvatarChip/AvatarChip";
 import styles from "./styles";
@@ -34,7 +36,7 @@ interface Props {
   options: EmployeeType[];
   value?: EmployeeOptionType | null;
   inputValue: string;
-  onInputChange: (value: string, reason: string) => void;
+  onInputChange: (value: string, reason: AutocompleteInputChangeReason) => void;
   onChange: (value: EmployeeType) => void;
   placeholder: string;
   isLoading?: boolean;

--- a/frontend/src/community/common/components/molecules/AutocompleteSearch/PeopleAutocompleteSearch.tsx
+++ b/frontend/src/community/common/components/molecules/AutocompleteSearch/PeopleAutocompleteSearch.tsx
@@ -1,4 +1,5 @@
 import { SxProps, Theme } from "@mui/material";
+import { AutocompleteInputChangeReason } from "@mui/material/Autocomplete";
 import { useMemo } from "react";
 
 import { EmployeeType } from "~community/people/types/EmployeeTypes";
@@ -14,7 +15,7 @@ interface Props {
   options: EmployeeType[];
   value?: EmployeeType;
   inputValue: string;
-  onInputChange: (value: string, reason: string) => void;
+  onInputChange: (value: string, reason: AutocompleteInputChangeReason) => void;
   onChange: (value: EmployeeType) => void;
   placeholder: string;
   isLoading?: boolean;

--- a/frontend/src/community/leave/components/molecules/CustomLeaveAllocationForm/CustomLeaveAllocationForm.tsx
+++ b/frontend/src/community/leave/components/molecules/CustomLeaveAllocationForm/CustomLeaveAllocationForm.tsx
@@ -326,8 +326,8 @@ const CustomLeaveAllocationForm: React.FC<Props> = ({
         onInputChange={(value, reason) => {
           if (reason === "reset") return;
           setSearchTerm(value);
-          if (values.employeeId !== 0 || values.assignedTo !== undefined) {
-            setFieldValue("employeeId", 0);
+          if (values.employeeId !== undefined || values.assignedTo !== undefined) {
+            setFieldValue("employeeId", undefined);
             setFieldValue("assignedTo", undefined);
           }
         }}

--- a/frontend/src/community/leave/components/molecules/CustomLeaveAllocationForm/CustomLeaveAllocationForm.tsx
+++ b/frontend/src/community/leave/components/molecules/CustomLeaveAllocationForm/CustomLeaveAllocationForm.tsx
@@ -323,13 +323,11 @@ const CustomLeaveAllocationForm: React.FC<Props> = ({
         options={(suggestions ?? []) as EmployeeType[]}
         value={values.assignedTo}
         inputValue={searchTerm}
-        onInputChange={(value) => {
+        onInputChange={(value, reason) => {
+          if (reason === "reset") return;
           setSearchTerm(value);
-          if (values.employeeId) {
-            setFieldValue("employeeId", 0);
-            setFieldValue("name", value);
-            setFieldValue("assignedTo", undefined);
-          }
+          setFieldValue("employeeId", 0);
+          setFieldValue("assignedTo", undefined);
         }}
         onChange={(value) => onSelectUser(value)}
         error={errors.employeeId}

--- a/frontend/src/community/leave/components/molecules/CustomLeaveAllocationForm/CustomLeaveAllocationForm.tsx
+++ b/frontend/src/community/leave/components/molecules/CustomLeaveAllocationForm/CustomLeaveAllocationForm.tsx
@@ -35,7 +35,13 @@ interface Props {
   errors: FormikErrors<CustomLeaveAllocationType>;
   setFieldValue: (
     field: string,
-    value: CustomLeaveAllocationType | number | Date | EmployeeType | string
+    value:
+      | CustomLeaveAllocationType
+      | number
+      | Date
+      | EmployeeType
+      | string
+      | undefined
   ) => void;
   setFieldError: (field: string, message: string | undefined) => void;
   translateText: (keys: string[]) => string;
@@ -317,7 +323,14 @@ const CustomLeaveAllocationForm: React.FC<Props> = ({
         options={(suggestions ?? []) as EmployeeType[]}
         value={values.assignedTo}
         inputValue={searchTerm}
-        onInputChange={(value) => setSearchTerm(value)}
+        onInputChange={(value) => {
+          setSearchTerm(value);
+          if (values.employeeId) {
+            setFieldValue("employeeId", 0);
+            setFieldValue("name", value);
+            setFieldValue("assignedTo", undefined);
+          }
+        }}
         onChange={(value) => onSelectUser(value)}
         error={errors.employeeId}
         isDisabled={

--- a/frontend/src/community/leave/components/molecules/CustomLeaveAllocationForm/CustomLeaveAllocationForm.tsx
+++ b/frontend/src/community/leave/components/molecules/CustomLeaveAllocationForm/CustomLeaveAllocationForm.tsx
@@ -326,8 +326,10 @@ const CustomLeaveAllocationForm: React.FC<Props> = ({
         onInputChange={(value, reason) => {
           if (reason === "reset") return;
           setSearchTerm(value);
-          setFieldValue("employeeId", 0);
-          setFieldValue("assignedTo", undefined);
+          if (values.employeeId !== 0 || values.assignedTo !== undefined) {
+            setFieldValue("employeeId", 0);
+            setFieldValue("assignedTo", undefined);
+          }
         }}
         onChange={(value) => onSelectUser(value)}
         error={errors.employeeId}

--- a/frontend/src/community/leave/components/molecules/CustomLeaveAllocationForm/CustomLeaveAllocationForm.tsx
+++ b/frontend/src/community/leave/components/molecules/CustomLeaveAllocationForm/CustomLeaveAllocationForm.tsx
@@ -129,7 +129,7 @@ const CustomLeaveAllocationForm: React.FC<Props> = ({
   }, [leaveTypesData]);
 
   useEffect(() => {
-    if (values.employeeId && suggestions) {
+    if (values.employeeId && values.assignedTo && suggestions) {
       const selectedUser = suggestions.find(
         (user) => user.employeeId === values.employeeId
       );
@@ -137,7 +137,7 @@ const CustomLeaveAllocationForm: React.FC<Props> = ({
         setSearchTerm(`${selectedUser.firstName} ${selectedUser.lastName}`);
       }
     }
-  }, [values.employeeId, suggestions]);
+  }, [values.employeeId, values.assignedTo, suggestions]);
 
   const onSelectUser = async (user: EmployeeType): Promise<void> => {
     if (user) {
@@ -326,8 +326,7 @@ const CustomLeaveAllocationForm: React.FC<Props> = ({
         onInputChange={(value, reason) => {
           if (reason === "reset") return;
           setSearchTerm(value);
-          if (values.employeeId !== undefined || values.assignedTo !== undefined) {
-            setFieldValue("employeeId", undefined);
+          if (values.assignedTo !== undefined) {
             setFieldValue("assignedTo", undefined);
           }
         }}

--- a/frontend/src/community/leave/components/molecules/CustomLeaveModals/AddLeaveAllocationModal/AddLeaveAllocationModal.tsx
+++ b/frontend/src/community/leave/components/molecules/CustomLeaveModals/AddLeaveAllocationModal/AddLeaveAllocationModal.tsx
@@ -121,6 +121,7 @@ const AddLeaveAllocationModal: React.FC<Props> = ({
   }, [values, setCurrentLeaveAllocationFormData]);
 
   const isSaveDisabled =
+    !values.assignedTo ||
     !values.employeeId ||
     !values.typeId ||
     !values.numberOfDaysOff ||

--- a/frontend/src/community/leave/components/molecules/CustomLeaveModals/EditLeaveAllocationModal/EditLeaveAllocationModal.tsx
+++ b/frontend/src/community/leave/components/molecules/CustomLeaveModals/EditLeaveAllocationModal/EditLeaveAllocationModal.tsx
@@ -133,6 +133,7 @@ const EditLeaveAllocationModal: React.FC<Props> = ({
   const isDeleteDisabled = currentEditingLeaveAllocation?.totalDaysUsed != 0;
 
   const isSaveDisabled =
+    !values.assignedTo ||
     !values.employeeId ||
     !values.typeId ||
     !values.numberOfDaysOff ||

--- a/frontend/src/community/leave/types/CustomLeaveAllocationTypes.tsx
+++ b/frontend/src/community/leave/types/CustomLeaveAllocationTypes.tsx
@@ -4,7 +4,7 @@ import { EmployeeType } from "~community/people/types/EmployeeTypes";
 
 export interface CustomLeaveAllocationType {
   entitlementId: number;
-  employeeId: number;
+  employeeId?: number;
   name?: string;
   numberOfDaysOff: number;
   typeId: number;

--- a/frontend/src/community/leave/types/CustomLeaveAllocationTypes.tsx
+++ b/frontend/src/community/leave/types/CustomLeaveAllocationTypes.tsx
@@ -4,7 +4,7 @@ import { EmployeeType } from "~community/people/types/EmployeeTypes";
 
 export interface CustomLeaveAllocationType {
   entitlementId: number;
-  employeeId?: number;
+  employeeId: number;
   name?: string;
   numberOfDaysOff: number;
   typeId: number;


### PR DESCRIPTION
…rch input change

## PR checklist

### TaskId: [(https://github.com/SkappHQ/skapp/issues/[id]) ](https://rootcode.skapp.com/pm/projects/SKAPP/items/1491)

### Summary
The issue was that custom leave allocation modal will save the employeeId when a employee was selected. The problem occurs when we try to backspace, the useEffect will trigger and apply that saved employeeId back into place from the suggestions. Since we are backspacing the suggestions include that same employee we want to backsapce. Resulting in not beign able to backspace and delete the selected employee. 

This fix will set the employee id to 0 so the the useEffect won't be setting the search term back to the one we are trying to delete unexpectedly.
-

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
