### PR TITLE
fix: restrict leave analytics to leave manager's supervised teams

### DIFF
--- a/backend/src/main/java/com/skapp/community/leaveplanner/service/impl/LeaveAnalyticsServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/service/impl/LeaveAnalyticsServiceImpl.java
@@ -363,6 +363,12 @@ public class LeaveAnalyticsServiceImpl implements LeaveAnalyticsService {
 
 		if (teamIds.contains(-1L) && !LeaveModuleUtil.isUserSuperAdminOrLeaveAdmin(currentUser)) {
 			teamIds = teamDao.findLeadingTeamIdsByManagerId(currentUser.getEmployee().getEmployeeId());
+			if (teamIds.isEmpty()) {
+				LeaveUtilizationResponseDto emptyResponse = new LeaveUtilizationResponseDto();
+				emptyResponse.setTotalLeaves(Collections.emptyMap());
+				emptyResponse.setTotalLeavesWithType(Collections.emptyList());
+				return new ResponseEntityDto(false, emptyResponse);
+			}
 		}
 
 		List<LeaveType> leaveTypes = typeIds.contains(-1L) ? leaveTypeDao.findAllByIsActive(true)
@@ -1005,6 +1011,13 @@ public class LeaveAnalyticsServiceImpl implements LeaveAnalyticsService {
 
 		if (teamIds.contains(-1L) && !LeaveModuleUtil.isUserSuperAdminOrLeaveAdmin(currentUser)) {
 			teamIds = teamDao.findLeadingTeamIdsByManagerId(currentUser.getEmployee().getEmployeeId());
+			if (teamIds.isEmpty()) {
+				OrganizationalAbsenceRateAnalyticsDto absenceRateAnalyticsDto = new OrganizationalAbsenceRateAnalyticsDto();
+				absenceRateAnalyticsDto.setCurrentAbsenceRate(0.0f);
+				absenceRateAnalyticsDto.setMonthBeforeAbsenceRate(0.0f);
+				absenceRateAnalyticsDto.setType(OrganizationalLeaveAnalyticsKPIAbsenceType.CURRENT_ABSENCE_RATE);
+				return new ResponseEntityDto(false, absenceRateAnalyticsDto);
+			}
 		}
 
 		LocalDate twoMonthsBackCurrentDay = currentDate.minusDays(59);

--- a/backend/src/main/java/com/skapp/community/leaveplanner/service/impl/LeaveAnalyticsServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/service/impl/LeaveAnalyticsServiceImpl.java
@@ -360,6 +360,11 @@ public class LeaveAnalyticsServiceImpl implements LeaveAnalyticsService {
 		}
 
 		User currentUser = userService.getCurrentUser();
+
+		if (teamIds.contains(-1L) && !LeaveModuleUtil.isUserSuperAdminOrLeaveAdmin(currentUser)) {
+			teamIds = teamDao.findLeadingTeamIdsByManagerId(currentUser.getEmployee().getEmployeeId());
+		}
+
 		List<LeaveType> leaveTypes = typeIds.contains(-1L) ? leaveTypeDao.findAllByIsActive(true)
 				: leaveTypeDao.findByTypeIdInAndIsActive(typeIds, true);
 
@@ -997,6 +1002,10 @@ public class LeaveAnalyticsServiceImpl implements LeaveAnalyticsService {
 		EmployeeRole employeeRole = currentUser.getEmployee().getEmployeeRole();
 		boolean isLeaveAdmin = employeeRole.getLeaveRole() != null
 				&& employeeRole.getLeaveRole().equals(Role.LEAVE_ADMIN);
+
+		if (teamIds.contains(-1L) && !LeaveModuleUtil.isUserSuperAdminOrLeaveAdmin(currentUser)) {
+			teamIds = teamDao.findLeadingTeamIdsByManagerId(currentUser.getEmployee().getEmployeeId());
+		}
 
 		LocalDate twoMonthsBackCurrentDay = currentDate.minusDays(59);
 		LocalDate oneMonthBackCurrentDay = currentDate.minusDays(29);


### PR DESCRIPTION
## Summary

- Leave managers could view leave analytics for **all employees** in the organization when `teamIds=-1` was passed to the analytics endpoints
- Fixed `getLeaveTypeBreakdown` (`/v1/leave/analytics/leave-type-breakdown`) and `getOrganizationalAbsenceRate` (`/v1/leave/analytics/organizational-absence-rates`) to scope data to the manager's supervised teams when the caller is a Leave Manager (not Super Admin or Leave Admin)
- Super Admins and Leave Admins retain full visibility — no behaviour change for them

## Root Cause

`LeaveModuleUtil.validateTeamsForLeaveAnalytics` short-circuits and returns immediately when `teamIds=-1`, skipping role-based access checks. The downstream queries then run with `null` team filter, returning data for all employees.

## Fix

After resolving the current user, if `teamIds=-1` and the user is not a Super Admin or Leave Admin, replace `-1` with the team IDs the manager leads via `teamDao.findLeadingTeamIdsByManagerId(...)`. This matches the pattern already used in `getManagerLeaveTrend`.

## Test plan

- [ ] Log in as a Leave Manager and call `GET /v1/leave/analytics/leave-type-breakdown?teamIds=-1` — response should only include leave data for employees in teams the manager supervises
- [ ] Log in as a Leave Manager and call `GET /v1/leave/analytics/organizational-absence-rates?teamIds=-1` — same scoping applies
- [ ] Log in as a Super Admin / Leave Admin and verify both endpoints still return data for all employees
- [ ] Verify the leave dashboard chart only shows scoped data for Leave Managers

🤖 Generated with [Claude Code](https://claude.com/claude-code)