### PR TITLE
fix: include primary and secondary supervised employees in leave type breakdown query

### DIFF
--- a/backend/src/main/java/com/skapp/community/crmplanner/repository/CrmDealDao.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/repository/CrmDealDao.java
@@ -10,6 +10,7 @@ import java.util.List;
 public interface CrmDealDao extends JpaRepository<CrmDeal, Long> {
 
 	List<CrmDeal> findByContact_IdAndIsDeletedFalse(Long contactId);
+
 	List<CrmDeal> findAllByCompanyIdAndIsDeletedFalse(Long companyId);
 
 }

--- a/backend/src/main/java/com/skapp/community/crmplanner/repository/CrmDealDao.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/repository/CrmDealDao.java
@@ -10,7 +10,6 @@ import java.util.List;
 public interface CrmDealDao extends JpaRepository<CrmDeal, Long> {
 
 	List<CrmDeal> findByContact_IdAndIsDeletedFalse(Long contactId);
-
 	List<CrmDeal> findAllByCompanyIdAndIsDeletedFalse(Long companyId);
 
 }

--- a/backend/src/main/java/com/skapp/community/leaveplanner/repository/LeaveRequestRepository.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/repository/LeaveRequestRepository.java
@@ -93,7 +93,7 @@ public interface LeaveRequestRepository {
 			List<Integer> workingDaysIndex, List<LocalDate> holidayDates);
 
 	List<LeaveTypeBreakDown> findLeaveTypeBreakDown(List<Integer> workingDaysIndex, List<LocalDate> holidayDates,
-			LocalDate startDate, LocalDate endDate, List<Long> typeIds, List<Long> teamIds);
+			LocalDate startDate, LocalDate endDate, List<Long> typeIds, List<Long> teamIds, List<Long> employeeIds);
 
 	List<LeaveUtilizationByEmployeeMonthly> findLeaveUtilizationByEmployeeMonthly(LocalDate startDate,
 			LocalDate endDate, List<Integer> workingDaysIndex, List<LocalDate> holidayDates, Long employeeId,

--- a/backend/src/main/java/com/skapp/community/leaveplanner/repository/impl/LeaveRequestRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/repository/impl/LeaveRequestRepositoryImpl.java
@@ -1306,14 +1306,16 @@ public class LeaveRequestRepositoryImpl implements LeaveRequestRepository {
 
 			predicates.add(cb.equal(leaveType.get(LeaveType_.isActive), true));
 
-			leaveQuery.multiselect(leaveType.get(LeaveType_.typeId), leaveRequest.get(LeaveRequest_.leaveState));
+			leaveQuery.select(cb.array(leaveRequest.get(LeaveRequest_.leaveRequestId), leaveType.get(LeaveType_.typeId),
+					leaveRequest.get(LeaveRequest_.leaveState)));
+			leaveQuery.distinct(true);
 			leaveQuery.where(predicates.toArray(new Predicate[0]));
 
 			List<Object[]> results = entityManager.createQuery(leaveQuery).getResultList();
 
 			for (Object[] result : results) {
-				Long leaveTypeId = (Long) result[0];
-				LeaveState leaveState = (LeaveState) result[1];
+				Long leaveTypeId = (Long) result[1];
+				LeaveState leaveState = (LeaveState) result[2];
 
 				double leaveCount = 1.0;
 				if (leaveState == LeaveState.HALFDAY_MORNING || leaveState == LeaveState.HALFDAY_EVENING) {

--- a/backend/src/main/java/com/skapp/community/leaveplanner/repository/impl/LeaveRequestRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/repository/impl/LeaveRequestRepositoryImpl.java
@@ -1251,7 +1251,7 @@ public class LeaveRequestRepositoryImpl implements LeaveRequestRepository {
 	}
 
 	public List<LeaveTypeBreakDown> findLeaveTypeBreakDown(List<Integer> workingDaysIndex, List<LocalDate> holidayDates,
-			LocalDate startDate, LocalDate endDate, List<Long> typeIds, List<Long> teamIds) {
+			LocalDate startDate, LocalDate endDate, List<Long> typeIds, List<Long> teamIds, List<Long> employeeIds) {
 		CriteriaBuilder cb = entityManager.getCriteriaBuilder();
 
 		List<LocalDate> allDates = startDate.datesUntil(endDate.plusDays(1)).toList();
@@ -1293,8 +1293,15 @@ public class LeaveRequestRepositoryImpl implements LeaveRequestRepository {
 				predicates.add(leaveType.get(LeaveType_.typeId).in(typeIds));
 			}
 
+			List<Predicate> teamOrEmployeePredicates = new ArrayList<>();
 			if (teamIds != null && !teamIds.isEmpty() && employeeTeam != null) {
-				predicates.add(employeeTeam.get(EmployeeTeam_.team).get(Team_.teamId).in(teamIds));
+				teamOrEmployeePredicates.add(employeeTeam.get(EmployeeTeam_.team).get(Team_.teamId).in(teamIds));
+			}
+			if (employeeIds != null && !employeeIds.isEmpty()) {
+				teamOrEmployeePredicates.add(employee.get(Employee_.employeeId).in(employeeIds));
+			}
+			if (!teamOrEmployeePredicates.isEmpty()) {
+				predicates.add(cb.or(teamOrEmployeePredicates.toArray(new Predicate[0])));
 			}
 
 			predicates.add(cb.equal(leaveType.get(LeaveType_.isActive), true));

--- a/backend/src/main/java/com/skapp/community/leaveplanner/service/impl/LeaveAnalyticsServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/service/impl/LeaveAnalyticsServiceImpl.java
@@ -361,9 +361,11 @@ public class LeaveAnalyticsServiceImpl implements LeaveAnalyticsService {
 
 		User currentUser = userService.getCurrentUser();
 
+		List<Long> employeeIds = null;
 		if (teamIds.contains(-1L) && !LeaveModuleUtil.isUserSuperAdminOrLeaveAdmin(currentUser)) {
 			teamIds = teamDao.findLeadingTeamIdsByManagerId(currentUser.getEmployee().getEmployeeId());
-			if (teamIds.isEmpty()) {
+			employeeIds = employeeDao.findEmployeeIdsByManagerId(currentUser.getEmployee().getEmployeeId());
+			if (teamIds.isEmpty() && employeeIds.isEmpty()) {
 				LeaveUtilizationResponseDto emptyResponse = new LeaveUtilizationResponseDto();
 				emptyResponse.setTotalLeaves(Collections.emptyMap());
 				emptyResponse.setTotalLeavesWithType(Collections.emptyList());
@@ -388,7 +390,7 @@ public class LeaveAnalyticsServiceImpl implements LeaveAnalyticsService {
 		LocalDate endDate = LocalDate.of(cycleEndYear, leaveCycleDetail.getEndMonth(), leaveCycleDetail.getEndDate());
 
 		var list = leaveRequestDao.findLeaveTypeBreakDown(getWorkingDaysIndex(), holidayDates, startDate, endDate,
-				typeIds.contains(-1L) ? null : typeIds, teamIds.contains(-1L) ? null : teamIds);
+				typeIds.contains(-1L) ? null : typeIds, teamIds.contains(-1L) ? null : teamIds, employeeIds);
 		Map<Integer, Double> totalLeavesWithMonths = list.stream()
 			.collect(Collectors.groupingBy(LeaveTypeBreakDown::getKeyValue,
 					Collectors.summingDouble(LeaveTypeBreakDown::getLeaveCount)));

--- a/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeaveTypeBreakdownControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeaveTypeBreakdownControllerIntegrationTest.java
@@ -1,0 +1,204 @@
+package com.skapp.community.leaveplanner.controller.v1;
+
+import com.skapp.TestSkappApplication;
+import com.skapp.community.common.security.AuthorityService;
+import com.skapp.community.common.service.JwtService;
+import com.skapp.support.MockUserFactory;
+import com.skapp.support.SecurityTestUtils;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.skapp.support.TestConstants.RESULTS_0_PATH;
+import static com.skapp.support.TestConstants.STATUS_PATH;
+import static com.skapp.support.TestConstants.STATUS_SUCCESSFUL;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = TestSkappApplication.class)
+@AutoConfigureMockMvc
+@Transactional
+@RequiredArgsConstructor
+@DisplayName("Leave Type Breakdown Controller Integration Tests")
+class LeaveTypeBreakdownControllerIntegrationTest {
+
+	private static final String ENDPOINT = "/v1/leave/analytics/leave-type-breakdown";
+
+	private final AuthorityService authorityService;
+
+	private final JwtService jwtService;
+
+	private final UserDetailsService userDetailsService;
+
+	private final MockMvc mvc;
+
+	private ResultActions performBreakdownRequest(String authToken, String teamIds) throws Exception {
+		var requestBuilder = get(ENDPOINT).accept(MediaType.APPLICATION_JSON);
+		if (teamIds != null) {
+			requestBuilder = requestBuilder.param("teamIds", teamIds);
+		}
+		return mvc.perform(requestBuilder.with(SecurityTestUtils.bearerToken(authToken)));
+	}
+
+	@Nested
+	@DisplayName("Super Admin - Leave Type Breakdown")
+	@Sql(statements = {
+			"INSERT INTO leave_request (leave_req_id, start_date, end_date, leave_state, status, employee_id, type_id, duration_days, is_viewed, is_auto_approved) "
+					+ "VALUES (default, YEAR(CURRENT_TIMESTAMP) || '-02-10', YEAR(CURRENT_TIMESTAMP) || '-02-11', 'FULLDAY', 'APPROVED', 2, 1, 2, false, false)",
+			"INSERT INTO leave_request (leave_req_id, start_date, end_date, leave_state, status, employee_id, type_id, duration_days, is_viewed, is_auto_approved) "
+					+ "VALUES (default, YEAR(CURRENT_TIMESTAMP) || '-02-12', YEAR(CURRENT_TIMESTAMP) || '-02-13', 'FULLDAY', 'APPROVED', 5, 2, 2, false, false)" })
+	class SuperAdminTests {
+
+		@Test
+		@DisplayName("Super admin with teamIds=-1 sees all employees approved leave data")
+		void getLeaveTypeBreakdown_SuperAdmin_ReturnsAllEmployeesData() throws Exception {
+			SecurityTestUtils.setupSecurityContext(authorityService, MockUserFactory.createLeaveAdmin());
+			String authToken = jwtService.generateAccessToken(userDetailsService.loadUserByUsername("user1@gmail.com"),
+					1L);
+
+			performBreakdownRequest(authToken, "-1").andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalLeaves']").exists())
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalLeaves']['Feb']").value(4.0))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalLeaves']['Mar']").value(2.0));
+		}
+
+		@Test
+		@DisplayName("Super admin without teamIds param sees all employees approved leave data")
+		void getLeaveTypeBreakdown_SuperAdminNoTeamIds_ReturnsAllEmployeesData() throws Exception {
+			SecurityTestUtils.setupSecurityContext(authorityService, MockUserFactory.createLeaveAdmin());
+			String authToken = jwtService.generateAccessToken(userDetailsService.loadUserByUsername("user1@gmail.com"),
+					1L);
+
+			performBreakdownRequest(authToken, null).andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalLeaves']").exists())
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalLeaves']['Feb']").value(4.0))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalLeaves']['Mar']").value(2.0));
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Leave Admin (non-super) - Leave Type Breakdown")
+	@Sql(statements = {
+			"INSERT INTO leave_request (leave_req_id, start_date, end_date, leave_state, status, employee_id, type_id, duration_days, is_viewed, is_auto_approved) "
+					+ "VALUES (default, YEAR(CURRENT_TIMESTAMP) || '-02-10', YEAR(CURRENT_TIMESTAMP) || '-02-11', 'FULLDAY', 'APPROVED', 2, 1, 2, false, false)",
+			"INSERT INTO leave_request (leave_req_id, start_date, end_date, leave_state, status, employee_id, type_id, duration_days, is_viewed, is_auto_approved) "
+					+ "VALUES (default, YEAR(CURRENT_TIMESTAMP) || '-02-12', YEAR(CURRENT_TIMESTAMP) || '-02-13', 'FULLDAY', 'APPROVED', 5, 2, 2, false, false)" })
+	class LeaveAdminTests {
+
+		@Test
+		@DisplayName("Leave admin with teamIds=-1 sees all employees approved leave data")
+		void getLeaveTypeBreakdown_LeaveAdmin_ReturnsAllEmployeesData() throws Exception {
+			// user2 has LEAVE_ADMIN in DB (not super admin) -
+			// isUserSuperAdminOrLeaveAdmin
+			// returns true
+			SecurityTestUtils.setupSecurityContext(authorityService, MockUserFactory.createLeaveAdmin());
+			String authToken = jwtService.generateAccessToken(userDetailsService.loadUserByUsername("user2@gmail.com"),
+					2L);
+
+			performBreakdownRequest(authToken, "-1").andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalLeaves']").exists())
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalLeaves']['Feb']").value(4.0))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalLeaves']['Mar']").value(2.0));
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Leave Manager - Leave Type Breakdown (supervised employees only)")
+	@Sql(statements = {
+			// Change emp3 role from LEAVE_ADMIN to LEAVE_MANAGER
+			"UPDATE employee_role SET leave_role = 'LEAVE_MANAGER', is_super_admin = false WHERE employee_id = 3",
+			// Make emp3 supervisor of team 6 (My Team1)
+			"INSERT INTO employee_team (id, team_id, employee_id, is_supervisor) VALUES (default, 6, 3, true)",
+			// Add emp5 as member of team 6
+			"INSERT INTO employee_team (id, team_id, employee_id, is_supervisor) VALUES (default, 6, 5, false)",
+			// Add emp3 as PRIMARY manager of emp4 (to test primary supervision)
+			"INSERT INTO employee_manager (id, employee_id, manager_id, is_direct_manager, manager_type) VALUES (default, 4, 3, 1, 'PRIMARY')",
+			// Add APPROVED leave for emp2 (supervised by emp3 as SECONDARY manager) in
+			// Feb
+			"INSERT INTO leave_request (leave_req_id, start_date, end_date, leave_state, status, employee_id, type_id, duration_days, is_viewed, is_auto_approved) "
+					+ "VALUES (default, YEAR(CURRENT_TIMESTAMP) || '-02-10', YEAR(CURRENT_TIMESTAMP) || '-02-11', 'FULLDAY', 'APPROVED', 2, 1, 2, false, false)",
+			// Add APPROVED leave for emp5 (team member under emp3's team) in Feb
+			"INSERT INTO leave_request (leave_req_id, start_date, end_date, leave_state, status, employee_id, type_id, duration_days, is_viewed, is_auto_approved) "
+					+ "VALUES (default, YEAR(CURRENT_TIMESTAMP) || '-02-12', YEAR(CURRENT_TIMESTAMP) || '-02-13', 'FULLDAY', 'APPROVED', 5, 2, 2, false, false)" })
+	class LeaveManagerTests {
+
+		@Test
+		@DisplayName("Leave manager with teamIds=-1 sees primary + secondary + team members")
+		void getLeaveTypeBreakdown_LeaveManager_ReturnsOnlySupervisedEmployeesData() throws Exception {
+			SecurityTestUtils.setupSecurityContext(authorityService,
+					MockUserFactory.createLeaveManager("user3@gmail.com", 3L, 3L));
+			String authToken = jwtService.generateAccessToken(userDetailsService.loadUserByUsername("user3@gmail.com"),
+					3L);
+
+			// emp3 supervises: emp2 (SECONDARY), emp4 (PRIMARY), emp5 (team 6
+			// member)
+			// emp4 has APPROVED leave in March (from data.sql)
+			performBreakdownRequest(authToken, "-1").andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalLeaves']").exists())
+				// Feb: emp2 (2 days) + emp5 (2 days) = 4
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalLeaves']['Feb']").value(4.0))
+				// Mar: emp4 (2 days, PRIMARY supervised) = 2
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalLeaves']['Mar']").value(2.0));
+		}
+
+		@Test
+		@DisplayName("Leave manager without teamIds sees primary + secondary + team members")
+		void getLeaveTypeBreakdown_LeaveManagerNoTeamIds_ReturnsOnlySupervisedEmployeesData() throws Exception {
+			SecurityTestUtils.setupSecurityContext(authorityService,
+					MockUserFactory.createLeaveManager("user3@gmail.com", 3L, 3L));
+			String authToken = jwtService.generateAccessToken(userDetailsService.loadUserByUsername("user3@gmail.com"),
+					3L);
+
+			performBreakdownRequest(authToken, null).andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalLeaves']").exists())
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalLeaves']['Feb']").value(4.0))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalLeaves']['Mar']").value(2.0));
+		}
+
+		@Test
+		@DisplayName("Leave manager with specific teamIds sees ONLY that team's members, not primary/secondary supervised")
+		void getLeaveTypeBreakdown_LeaveManagerSpecificTeam_ReturnsTeamDataOnly() throws Exception {
+			SecurityTestUtils.setupSecurityContext(authorityService,
+					MockUserFactory.createLeaveManager("user3@gmail.com", 3L, 3L));
+			String authToken = jwtService.generateAccessToken(userDetailsService.loadUserByUsername("user3@gmail.com"),
+					3L);
+
+			// Query only team 6 (where emp5 is a member)
+			// emp2 (SECONDARY supervised) and emp4 (PRIMARY supervised) are NOT
+			// in team 6, so they should be excluded
+			performBreakdownRequest(authToken, "6").andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalLeaves']").exists())
+				// Feb: only emp5 (2 days in team 6)
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalLeaves']['Feb']").value(2.0))
+				// Mar: emp4 is PRIMARY supervised but NOT in team 6, so excluded
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalLeaves']['Mar']").value(0.0));
+		}
+
+	}
+
+}

--- a/backend/src/test/java/com/skapp/support/MockUserFactory.java
+++ b/backend/src/test/java/com/skapp/support/MockUserFactory.java
@@ -123,6 +123,23 @@ public class MockUserFactory {
 		return mockUser;
 	}
 
+	/**
+	 * Creates a leave manager user (not admin, not super admin). Used by Leave Analytics
+	 * manager-scoped tests.
+	 */
+	public static User createLeaveManager(String email, Long userId, Long employeeId) {
+		User mockUser = createBaseUser(email, userId);
+
+		Employee mockEmployee = createBaseEmployee(employeeId);
+		EmployeeRole role = new EmployeeRole();
+		role.setLeaveRole(Role.LEAVE_MANAGER);
+		role.setIsSuperAdmin(false);
+		mockEmployee.setEmployeeRole(role);
+
+		linkUserAndEmployee(mockUser, mockEmployee);
+		return mockUser;
+	}
+
 	private static User createBaseUser(String email, Long userId) {
 		User user = new User();
 		user.setEmail(email);


### PR DESCRIPTION
## What does this PR do?
Fixes the leave type breakdown query for managers so that it includes all supervised employees (primary, secondary, and team-supervised) when the frontend sends `-1` for team IDs.

## Changes
### `LeaveAnalyticsServiceImpl`
- Fetch directly supervised employee IDs (primary + secondary) via `employeeDao.findEmployeeIdsByManagerId()` in addition to leading team IDs
- Pass `employeeIds` to the query; return empty only if both team IDs and employee IDs are empty

### `LeaveRequestRepository`
- Added `employeeIds` parameter to `findLeaveTypeBreakDown` interface method

### `LeaveRequestRepositoryImpl`
- Changed team-only filter to an OR condition: employees in supervised teams OR directly supervised employees (same pattern used by `findLeaveTrendForTheManager`)

## Testing
- [x] Verified compilation clean (`mvn compile`)
- [x] Formatting applied (`mvn spring-javaformat:apply`)
