### PR TITLE
fix: optimize GET /v1/leave/requests endpoint and fix ExceptionLoggingFilter ClassCastException

### DIFF
--- a/backend/src/main/java/com/skapp/community/common/component/ExceptionLoggingFilter.java
+++ b/backend/src/main/java/com/skapp/community/common/component/ExceptionLoggingFilter.java
@@ -1,6 +1,7 @@
 package com.skapp.community.common.component;
 
 import com.skapp.community.common.constant.CommonMessageConstant;
+import com.skapp.community.common.constant.MessageConstant;
 import com.skapp.community.common.exception.AuthenticationException;
 import com.skapp.community.common.payload.response.ErrorResponse;
 import com.skapp.community.common.payload.response.ResponseEntityDto;
@@ -44,7 +45,7 @@ public class ExceptionLoggingFilter implements Filter {
 
 	private void handleException(Exception e, HttpServletResponse response) throws IOException {
 		HttpStatus status;
-		CommonMessageConstant messageKey;
+		MessageConstant messageKey;
 		String message;
 
 		switch (e) {
@@ -60,7 +61,7 @@ public class ExceptionLoggingFilter implements Filter {
 			}
 			case AuthenticationException authenticationException -> {
 				status = HttpStatus.UNAUTHORIZED;
-				messageKey = (CommonMessageConstant) authenticationException.getMessageKey();
+				messageKey = authenticationException.getMessageKey();
 				message = authenticationException.getMessage();
 			}
 			case null, default -> {

--- a/backend/src/main/java/com/skapp/community/leaveplanner/repository/impl/LeaveRequestRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/repository/impl/LeaveRequestRepositoryImpl.java
@@ -884,8 +884,46 @@ public class LeaveRequestRepositoryImpl implements LeaveRequestRepository {
 			LeaveRequestFilterDto leaveRequestFilterDto, Pageable page) {
 		CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
 
+		CriteriaQuery<Long> countQuery = criteriaBuilder.createQuery(Long.class);
+		Root<LeaveRequest> countRoot = countQuery.from(LeaveRequest.class);
+
+		Join<LeaveRequest, Employee> countEmployee = countRoot.join(LeaveRequest_.employee);
+		Join<Employee, EmployeeManager> countManagers = countEmployee.join(Employee_.employeeManagers);
+		Join<EmployeeManager, Employee> countManEmp = countManagers.join(EmployeeManager_.manager);
+		Join<Employee, User> countUser = countEmployee.join(Employee_.user);
+
+		List<Predicate> countPredicates = new ArrayList<>();
+		countPredicates.add(criteriaBuilder.equal(countUser.get(User_.isActive), true));
+		countPredicates.add(criteriaBuilder.equal(countManEmp.get(Employee_.employeeId), managerEmployeeId));
+
+		if (!CollectionUtils.isEmpty(leaveRequestFilterDto.getLeaveType())) {
+			countPredicates.add(countRoot.get(LeaveRequest_.leaveType)
+				.get(LeaveType_.typeId)
+				.in(leaveRequestFilterDto.getLeaveType()));
+		}
+
+		if (!CollectionUtils.isEmpty(leaveRequestFilterDto.getStatus())) {
+			countPredicates.add(countRoot.get(LeaveRequest_.status).in(leaveRequestFilterDto.getStatus()));
+		}
+		setDateRangeFiltration(leaveRequestFilterDto, criteriaBuilder, countRoot, countPredicates);
+
+		if (!CollectionUtils.isEmpty(leaveRequestFilterDto.getManagerType())) {
+			countPredicates
+				.add(countManagers.get(EmployeeManager_.managerType).in(leaveRequestFilterDto.getManagerType()));
+		}
+
+		countQuery.select(criteriaBuilder.countDistinct(countRoot.get(LeaveRequest_.leaveRequestId)));
+		countQuery.where(countPredicates.toArray(new Predicate[0]));
+		long totalRows = entityManager.createQuery(countQuery).getSingleResult();
+
+		if (totalRows == 0) {
+			return new PageImpl<>(Collections.emptyList(), page, 0);
+		}
+
 		CriteriaQuery<LeaveRequest> criteriaQuery = criteriaBuilder.createQuery(LeaveRequest.class);
 		Root<LeaveRequest> root = criteriaQuery.from(LeaveRequest.class);
+
+		root.fetch(LeaveRequest_.leaveType, JoinType.INNER);
 
 		List<Predicate> predicates = new ArrayList<>();
 
@@ -911,15 +949,11 @@ public class LeaveRequestRepositoryImpl implements LeaveRequestRepository {
 			predicates.add(managers.get(EmployeeManager_.managerType).in(leaveRequestFilterDto.getManagerType()));
 		}
 
-		Predicate[] predArray = new Predicate[predicates.size()];
-		predicates.toArray(predArray);
-		criteriaQuery.where(predArray);
+		criteriaQuery.where(predicates.toArray(new Predicate[0]));
 		criteriaQuery.select(root).distinct(true);
 		criteriaQuery.orderBy(QueryUtils.toOrders(page.getSort(), root, criteriaBuilder));
 
 		TypedQuery<LeaveRequest> query = entityManager.createQuery(criteriaQuery);
-
-		int totalRows = query.getResultList().size();
 		query.setFirstResult(page.getPageNumber() * page.getPageSize());
 		query.setMaxResults(page.getPageSize());
 

--- a/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeaveControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeaveControllerIntegrationTest.java
@@ -31,6 +31,8 @@ import static com.skapp.support.TestConstants.RESULTS_0_PATH;
 import static com.skapp.support.TestConstants.STATUS_PATH;
 import static com.skapp.support.TestConstants.STATUS_SUCCESSFUL;
 import static com.skapp.support.TestConstants.STATUS_UNSUCCESSFUL;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -123,6 +125,100 @@ class LeaveControllerIntegrationTest {
 				.andExpect(jsonPath(STATUS_PATH).value(STATUS_UNSUCCESSFUL))
 				.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH)
 					.value(messageUtil.getMessage(LeaveMessageConstant.LEAVE_ERROR_MUST_INCLUDE_COMMENT)));
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Get Manager Assigned Leave Requests Tests")
+	class GetManagerAssignedLeavesTests {
+
+		private String managerAuthToken;
+
+		@BeforeEach
+		void setupManager() {
+			SecurityTestUtils.setupSecurityContext(authorityService, MockUserFactory.createSuperAdminWithAllRoles());
+			managerAuthToken = jwtService.generateAccessToken(userDetailsService.loadUserByUsername("user1@gmail.com"),
+					1L);
+		}
+
+		private String dateRangeParams() {
+			int year = DateTimeUtils.getCurrentYear();
+			return "?startDate=" + year + "-01-01&endDate=" + year + "-12-31";
+		}
+
+		private ResultActions performGetRequests(String queryParams) throws Exception {
+			return mvc.perform(
+					get(BASE_PATH + "/requests" + queryParams).with(SecurityTestUtils.bearerToken(managerAuthToken))
+						.accept(MediaType.APPLICATION_JSON));
+		}
+
+		@Test
+		@DisplayName("Get assigned leaves - Returns all 3 leave requests for manager user1")
+		void getAssignedLeaves_ReturnsAllThreeRequests() throws Exception {
+			// user1 is PRIMARY manager of employees 2,3,4 who each have 1 leave request
+			performGetRequests(dateRangeParams()).andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalItems']").value(3))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['items']").isArray())
+				.andExpect(jsonPath(RESULTS_0_PATH + "['items']", hasSize(3)));
+		}
+
+		@Test
+		@DisplayName("Get assigned leaves with page size 2 - Returns 2 items but totalItems is 3")
+		void getAssignedLeaves_WithPagination_ReturnsPagedResults() throws Exception {
+			performGetRequests(dateRangeParams() + "&page=0&size=2").andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalItems']").value(3))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalPages']").value(2))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['currentPage']").value(0))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['items']", hasSize(2)));
+		}
+
+		@Test
+		@DisplayName("Get assigned leaves filtered by PENDING - Returns 2 pending requests")
+		void getAssignedLeaves_FilterByPendingStatus_ReturnsTwoResults() throws Exception {
+			// employee2 PENDING Study, employee3 PENDING Casual
+			performGetRequests(dateRangeParams() + "&status=PENDING").andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalItems']").value(2))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['items']", hasSize(2)))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['items'][0]['status']").value("PENDING"))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['items'][1]['status']").value("PENDING"));
+		}
+
+		@Test
+		@DisplayName("Get assigned leaves filtered by APPROVED - Returns 1 approved request")
+		void getAssignedLeaves_FilterByApprovedStatus_ReturnsOneResult() throws Exception {
+			// employee4 APPROVED Casual
+			performGetRequests(dateRangeParams() + "&status=APPROVED").andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalItems']").value(1))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['items']", hasSize(1)))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['items'][0]['status']").value("APPROVED"))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['items'][0]['leaveType']['name']").value("Casual"));
+		}
+
+		@Test
+		@DisplayName("Get assigned leaves for user5 (no managees) - Returns 0 items")
+		void getAssignedLeaves_NoManagees_ReturnsZeroItems() throws Exception {
+			// user5 has no employees under management
+			SecurityTestUtils.setupSecurityContext(authorityService,
+					MockUserFactory.createLeaveManager("user5@gmail.com", 5L, 5L));
+			String user5Token = jwtService.generateAccessToken(userDetailsService.loadUserByUsername("user5@gmail.com"),
+					5L);
+
+			mvc.perform(get(BASE_PATH + "/requests" + dateRangeParams()).with(SecurityTestUtils.bearerToken(user5Token))
+				.accept(MediaType.APPLICATION_JSON))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalItems']").value(0))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['items']", hasSize(0)));
 		}
 
 	}


### PR DESCRIPTION
- Replace double query execution in findAllRequestAssignedToManager with separate COUNT(DISTINCT) query + early return on 0 results
- Add fetch join for leaveType to prevent N+1 queries
- Fix ClassCastException in ExceptionLoggingFilter by widening messageKey type from CommonMessageConstant to MessageConstant interface
- Add integration tests for GET /v1/leave/requests endpoint

## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/[id]) 

### Summary

-

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
