### PR TITLE
test: add GET /v1/leave integration tests and optimize query performance

### DIFF
--- a/backend/src/main/java/com/skapp/community/leaveplanner/repository/impl/LeaveRequestRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/repository/impl/LeaveRequestRepositoryImpl.java
@@ -760,14 +760,6 @@ public class LeaveRequestRepositoryImpl implements LeaveRequestRepository {
 
 		List<Predicate> predicates = new ArrayList<>();
 
-		CriteriaQuery<Long> countQuery = criteriaBuilder.createQuery(Long.class);
-		Root<LeaveRequest> countRoot = countQuery.from(LeaveRequest.class);
-		buildEmployeeLeavePredicates(criteriaBuilder, countRoot, predicates, employeeId, leaveRequestFilterDto);
-		countQuery.select(criteriaBuilder.count(countRoot));
-		countQuery.where(predicates.toArray(new Predicate[0]));
-		long totalRows = entityManager.createQuery(countQuery).getSingleResult();
-
-		predicates.clear();
 		CriteriaQuery<LeaveRequest> criteriaQuery = criteriaBuilder.createQuery(LeaveRequest.class);
 		Root<LeaveRequest> root = criteriaQuery.from(LeaveRequest.class);
 		buildEmployeeLeavePredicates(criteriaBuilder, root, predicates, employeeId, leaveRequestFilterDto);
@@ -778,9 +770,20 @@ public class LeaveRequestRepositoryImpl implements LeaveRequestRepository {
 		if (page.isPaged()) {
 			query.setFirstResult(page.getPageNumber() * page.getPageSize());
 			query.setMaxResults(page.getPageSize());
+
+			predicates.clear();
+			CriteriaQuery<Long> countQuery = criteriaBuilder.createQuery(Long.class);
+			Root<LeaveRequest> countRoot = countQuery.from(LeaveRequest.class);
+			buildEmployeeLeavePredicates(criteriaBuilder, countRoot, predicates, employeeId, leaveRequestFilterDto);
+			countQuery.select(criteriaBuilder.count(countRoot));
+			countQuery.where(predicates.toArray(new Predicate[0]));
+			long totalRows = entityManager.createQuery(countQuery).getSingleResult();
+
+			return new PageImpl<>(query.getResultList(), page, totalRows);
 		}
 
-		return new PageImpl<>(query.getResultList(), page, totalRows);
+		List<LeaveRequest> results = query.getResultList();
+		return new PageImpl<>(results, page, results.size());
 	}
 
 	private void buildEmployeeLeavePredicates(CriteriaBuilder criteriaBuilder, Root<LeaveRequest> root,

--- a/backend/src/main/java/com/skapp/community/leaveplanner/repository/impl/LeaveRequestRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/repository/impl/LeaveRequestRepositoryImpl.java
@@ -758,13 +758,34 @@ public class LeaveRequestRepositoryImpl implements LeaveRequestRepository {
 
 		CriteriaBuilder criteriaBuilder = entityManager.getCriteriaBuilder();
 
-		CriteriaQuery<LeaveRequest> criteriaQuery = criteriaBuilder.createQuery(LeaveRequest.class);
-		Root<LeaveRequest> root = criteriaQuery.from(LeaveRequest.class);
-
 		List<Predicate> predicates = new ArrayList<>();
 
-		Join<LeaveRequest, Employee> employee = root.join(LeaveRequest_.EMPLOYEE);
-		predicates.add(criteriaBuilder.equal(employee.get(Employee_.EMPLOYEE_ID), employeeId));
+		CriteriaQuery<Long> countQuery = criteriaBuilder.createQuery(Long.class);
+		Root<LeaveRequest> countRoot = countQuery.from(LeaveRequest.class);
+		buildEmployeeLeavePredicates(criteriaBuilder, countRoot, predicates, employeeId, leaveRequestFilterDto);
+		countQuery.select(criteriaBuilder.count(countRoot));
+		countQuery.where(predicates.toArray(new Predicate[0]));
+		long totalRows = entityManager.createQuery(countQuery).getSingleResult();
+
+		predicates.clear();
+		CriteriaQuery<LeaveRequest> criteriaQuery = criteriaBuilder.createQuery(LeaveRequest.class);
+		Root<LeaveRequest> root = criteriaQuery.from(LeaveRequest.class);
+		buildEmployeeLeavePredicates(criteriaBuilder, root, predicates, employeeId, leaveRequestFilterDto);
+		criteriaQuery.where(predicates.toArray(new Predicate[0]));
+		criteriaQuery.orderBy(QueryUtils.toOrders(page.getSort(), root, criteriaBuilder));
+
+		TypedQuery<LeaveRequest> query = entityManager.createQuery(criteriaQuery);
+		if (page.isPaged()) {
+			query.setFirstResult(page.getPageNumber() * page.getPageSize());
+			query.setMaxResults(page.getPageSize());
+		}
+
+		return new PageImpl<>(query.getResultList(), page, totalRows);
+	}
+
+	private void buildEmployeeLeavePredicates(CriteriaBuilder criteriaBuilder, Root<LeaveRequest> root,
+			List<Predicate> predicates, Long employeeId, LeaveRequestFilterDto leaveRequestFilterDto) {
+		predicates.add(criteriaBuilder.equal(root.get(LeaveRequest_.EMPLOYEE).get(Employee_.EMPLOYEE_ID), employeeId));
 
 		if (!CollectionUtils.isEmpty(leaveRequestFilterDto.getLeaveType())) {
 			predicates.add(root.get(LeaveRequest_.LEAVE_TYPE)
@@ -784,19 +805,6 @@ public class LeaveRequestRepositoryImpl implements LeaveRequestRepository {
 							leaveRequestFilterDto.getEndDate()));
 			predicates.add(dateBetween);
 		}
-
-		Predicate[] predArray = new Predicate[predicates.size()];
-		predicates.toArray(predArray);
-		criteriaQuery.where(predArray);
-		criteriaQuery.orderBy(QueryUtils.toOrders(page.getSort(), root, criteriaBuilder));
-
-		TypedQuery<LeaveRequest> query = entityManager.createQuery(criteriaQuery);
-
-		int totalRows = query.getResultList().size();
-		query.setFirstResult(page.getPageNumber() * page.getPageSize());
-		query.setMaxResults(page.getPageSize());
-
-		return new PageImpl<>(query.getResultList(), page, totalRows);
 	}
 
 	@Override

--- a/backend/src/main/java/com/skapp/community/leaveplanner/service/impl/LeaveServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/service/impl/LeaveServiceImpl.java
@@ -373,15 +373,15 @@ public class LeaveServiceImpl implements LeaveService {
 		User currentUser = userService.getCurrentUser();
 		Long empId = currentUser.getUserId();
 
-		int pageSize = leaveRequestFilterDto.getSize();
+		Sort sort = Sort.by(leaveRequestFilterDto.getSortOrder(), leaveRequestFilterDto.getSortKey().toString());
 
-		boolean isExport = leaveRequestFilterDto.getIsExport();
-		if (isExport) {
-			pageSize = (int) leaveRequestDao.count();
+		Pageable pageable;
+		if (Boolean.TRUE.equals(leaveRequestFilterDto.getIsExport())) {
+			pageable = Pageable.unpaged(sort);
 		}
-
-		Pageable pageable = PageRequest.of(leaveRequestFilterDto.getPage(), pageSize,
-				Sort.by(leaveRequestFilterDto.getSortOrder(), leaveRequestFilterDto.getSortKey().toString()));
+		else {
+			pageable = PageRequest.of(leaveRequestFilterDto.getPage(), leaveRequestFilterDto.getSize(), sort);
+		}
 
 		Page<LeaveRequest> leaveRequests = leaveRequestDao.findAllRequestsByEmployee(empId, leaveRequestFilterDto,
 				pageable);

--- a/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeaveControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeaveControllerIntegrationTest.java
@@ -135,7 +135,6 @@ class LeaveControllerIntegrationTest {
 	}
 
 	@Nested
-	@Nested
 	@DisplayName("Get Manager Assigned Leave Requests Tests")
 	class GetManagerAssignedLeavesTests {
 

--- a/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeaveControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/leaveplanner/controller/v1/LeaveControllerIntegrationTest.java
@@ -26,12 +26,17 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.databind.json.JsonMapper;
 
+import java.time.LocalDate;
+import java.time.Month;
+
 import static com.skapp.support.TestConstants.MESSAGE_PATH;
 import static com.skapp.support.TestConstants.RESULTS_0_PATH;
 import static com.skapp.support.TestConstants.STATUS_PATH;
 import static com.skapp.support.TestConstants.STATUS_SUCCESSFUL;
 import static com.skapp.support.TestConstants.STATUS_UNSUCCESSFUL;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -130,6 +135,7 @@ class LeaveControllerIntegrationTest {
 	}
 
 	@Nested
+	@Nested
 	@DisplayName("Get Manager Assigned Leave Requests Tests")
 	class GetManagerAssignedLeavesTests {
 
@@ -219,6 +225,119 @@ class LeaveControllerIntegrationTest {
 				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
 				.andExpect(jsonPath(RESULTS_0_PATH + "['totalItems']").value(0))
 				.andExpect(jsonPath(RESULTS_0_PATH + "['items']", hasSize(0)));
+		}
+
+	}
+
+	@Nested
+	@DisplayName("Get Current User Leave Requests Tests")
+	class GetCurrentUserLeaveRequestsTests {
+
+		@Test
+		@DisplayName("Returns leave requests with default parameters")
+		void getLeaveRequests_NoFilters_ReturnsOk() throws Exception {
+			performRequest(get(BASE_PATH).accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['items']").isArray())
+				.andExpect(jsonPath(RESULTS_0_PATH + "['currentPage']").value(0))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalItems']").isNumber())
+				.andExpect(jsonPath(RESULTS_0_PATH + "['totalPages']").isNumber());
+		}
+
+		@Test
+		@DisplayName("Returns leave requests filtered by PENDING status")
+		void getLeaveRequests_PendingStatus_ReturnsPendingOnly() throws Exception {
+			performRequest(get(BASE_PATH).param("status", "PENDING").accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['items']").isArray())
+				.andExpect(jsonPath(RESULTS_0_PATH + "['items'][0]['status']").value("PENDING"));
+		}
+
+		@Test
+		@DisplayName("Returns leave requests filtered by date range")
+		void getLeaveRequests_DateRange_ReturnsFilteredResults() throws Exception {
+			String startDate = LocalDate.of(LocalDate.now().getYear(), Month.JANUARY, 1).toString();
+			String endDate = LocalDate.of(LocalDate.now().getYear(), Month.DECEMBER, 31).toString();
+			performRequest(get(BASE_PATH).param("startDate", startDate)
+				.param("endDate", endDate)
+				.accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['items']").isArray())
+				.andExpect(jsonPath(RESULTS_0_PATH + "['items']", hasSize(greaterThanOrEqualTo(1))));
+		}
+
+		@Test
+		@DisplayName("Returns leave requests filtered by leave type")
+		void getLeaveRequests_LeaveTypeFilter_ReturnsFilteredResults() throws Exception {
+			performRequest(get(BASE_PATH).param("leaveType", "1").accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['items']").isArray());
+		}
+
+		@Test
+		@DisplayName("Returns leave requests with pagination parameters")
+		void getLeaveRequests_WithPagination_ReturnsPagedResults() throws Exception {
+			performRequest(get(BASE_PATH).param("page", "0").param("size", "6").accept(MediaType.APPLICATION_JSON))
+				.andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['currentPage']").value(0))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['items']", hasSize(lessThanOrEqualTo(6))));
+		}
+
+		@Test
+		@DisplayName("Returns leave requests sorted by CREATED_DATE")
+		void getLeaveRequests_SortByCreatedDate_ReturnsSortedResults() throws Exception {
+			performRequest(get(BASE_PATH).param("sortKey", "CREATED_DATE")
+				.param("sortOrder", "DESC")
+				.accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['items']").isArray());
+		}
+
+		@Test
+		@DisplayName("Returns leave requests with all filters combined")
+		void getLeaveRequests_AllFiltersCombined_ReturnsFilteredResults() throws Exception {
+			String startDate = LocalDate.of(LocalDate.now().getYear(), Month.JANUARY, 1).toString();
+			String endDate = LocalDate.of(LocalDate.now().getYear(), Month.DECEMBER, 31).toString();
+			performRequest(get(BASE_PATH).param("status", "PENDING")
+				.param("startDate", startDate)
+				.param("endDate", endDate)
+				.param("page", "0")
+				.param("sortKey", "CREATED_DATE")
+				.param("size", "6")
+				.accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['items']").isArray())
+				.andExpect(jsonPath(RESULTS_0_PATH + "['currentPage']").value(0));
+		}
+
+		@Test
+		@DisplayName("Returns empty results for future date range with no leaves")
+		void getLeaveRequests_FutureDateRange_ReturnsEmptyResults() throws Exception {
+			int nextYear = LocalDate.now().getYear() + 1;
+			String startDate = LocalDate.of(nextYear, Month.JANUARY, 1).toString();
+			String endDate = LocalDate.of(nextYear, Month.DECEMBER, 31).toString();
+			performRequest(get(BASE_PATH).param("startDate", startDate)
+				.param("endDate", endDate)
+				.accept(MediaType.APPLICATION_JSON)).andDo(print())
+				.andExpect(status().isOk())
+				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+				.andExpect(jsonPath(RESULTS_0_PATH + "['items']", hasSize(0)));
+		}
+
+		@Test
+		@DisplayName("Returns 401 when no authentication token is provided")
+		void getLeaveRequests_NoAuth_ReturnsUnauthorized() throws Exception {
+			mvc.perform(get(BASE_PATH).accept(MediaType.APPLICATION_JSON))
+				.andDo(print())
+				.andExpect(status().isUnauthorized());
 		}
 
 	}


### PR DESCRIPTION
## Changes

### Integration Tests
- Added 9 integration tests for \GET /v1/leave\ (getCurrentUserLeaveRequests):
  - No filters returns paginated response
  - PENDING status filter
  - Date range filter
  - Leave type filter
  - Pagination parameters
  - Sort by CREATED_DATE
  - All filters combined
  - Future date range returns empty
  - Unauthenticated request returns 401

### Query Optimization
- **Separate COUNT query**: Replaced loading all entities into memory for count with a lightweight \SELECT COUNT(*)\ criteria query
- **Removed unnecessary JOIN**: Filter by \employee_id\ FK column directly using path expression instead of joining the Employee table
- **Fixed isExport**: Used \Pageable.unpaged()\ instead of \leaveRequestDao.count()\ which was counting ALL leave requests regardless of user
- **Unpaged handling**: Repository respects \page.isPaged()\ to skip offset/limit for export

### Test Results
All 178 tests pass.