### PR TITLE
feat: guest user to internal user conversion - frontend

### DIFF
--- a/frontend/src/community/people/components/molecules/AddNewResourceModal/AddNewResourceModal.tsx
+++ b/frontend/src/community/people/components/molecules/AddNewResourceModal/AddNewResourceModal.tsx
@@ -141,7 +141,7 @@ const AddNewResourceModal = () => {
 
   const validateWorkEmail = () => {
     const updatedData = checkEmailAndIdentificationNo;
-    if (updatedData?.isWorkEmailExists) {
+    if (updatedData?.isWorkEmailExists && !updatedData?.isGuestUser) {
       setFieldError("email", translateText(["uniqueEmailError"]));
       return false;
     }

--- a/frontend/src/community/people/components/organisms/AddNewResourceFlow/EmploymentDetailsSection/EmploymentDetailsSection.tsx
+++ b/frontend/src/community/people/components/organisms/AddNewResourceFlow/EmploymentDetailsSection/EmploymentDetailsSection.tsx
@@ -449,7 +449,7 @@ const EmploymentDetailsSection = forwardRef<FormMethods, Props>(
     useEffect(() => {
       const updatedData = checkEmailAndIdentificationNo;
       if (updatedData && isSuccess && !isProfileView && !isManager) {
-        if (updatedData.isWorkEmailExists && !formik.touched.workEmail) {
+        if (updatedData.isWorkEmailExists && !formik.touched.workEmail && !updatedData.isGuestUser) {
           setIsUniqueEmail(false);
         } else {
           setIsUniqueEmail(true);

--- a/frontend/src/community/people/hooks/useEmployeeDetailsFormHandler.tsx
+++ b/frontend/src/community/people/hooks/useEmployeeDetailsFormHandler.tsx
@@ -393,7 +393,7 @@ const useEmployeeDetailsFormHandler = ({
   useEffect(() => {
     const updatedData = checkEmailAndIdentificationNo;
     if (updatedData && isSuccess && !isProfileView && !isManager) {
-      if (updatedData.isWorkEmailExists && !formik.touched.email) {
+      if (updatedData.isWorkEmailExists && !formik.touched.email && !updatedData.isGuestUser) {
         setIsUniqueEmail(false);
       } else {
         setIsUniqueEmail(true);

--- a/frontend/src/community/people/types/EmployeeTypes.tsx
+++ b/frontend/src/community/people/types/EmployeeTypes.tsx
@@ -444,6 +444,7 @@ export interface EmployeeDataExists {
   isIdentificationNoExists: boolean;
   isWorkEmailExists: boolean;
   isGoogleDomain: boolean;
+  isGuestUser: boolean;
 }
 
 export interface QuickAddEmployeePayload {


### PR DESCRIPTION
## Summary
Frontend changes to support guest user to internal user conversion. Allows the add employee flow to proceed when the email belongs to an existing guest user.

## Changes
- Added isGuestUser field to EmployeeDataExists interface
- Updated email validation in AddNewResourceModal to allow guest user emails
- Updated EmploymentDetailsSection to skip error for guest users
- Updated useEmployeeDetailsFormHandler to skip error for guest users

## Files Changed
- EmployeeTypes.tsx
- AddNewResourceModal.tsx
- EmploymentDetailsSection.tsx
- useEmployeeDetailsFormHandler.tsx

## Depends On
- #1401 (backend PR)