### PR TITLE
fix(ui): correct user bulk upload template ui text

### DIFF
--- a/frontend/src/community/common/assets/languages/english/peopleModule.json
+++ b/frontend/src/community/common/assets/languages/english/peopleModule.json
@@ -321,6 +321,8 @@
     "reactivateSuccessMessage": "The user has been successfully reactivated",
     "reactiveUserDescription": "The user will be reassigned to the same configurations prior to the deactivation. Profile details can be edited once reactivated.",
     "deactivatedLabel": "Deactivated",
+    "downloadExcelDes": "Download the Excel template, fill in the details of the people you wish to add to the organization, and then upload the completed file.",
+    "downloadExcelButton": "Download Excel template",
     "downloadCsvDes": "Download the CSV template, fill in the details of the people you wish to add to the organization, and then upload the completed file.",
     "downloadCsvButton": "Download CSV template",
     "downloadCsvDesQuickWizard": "Download the template, fill in the details for all people and upload the completed file.",

--- a/frontend/src/community/people/components/molecules/UserBulkUploadModals/UserBulkCsvDownload.test.tsx
+++ b/frontend/src/community/people/components/molecules/UserBulkUploadModals/UserBulkCsvDownload.test.tsx
@@ -44,8 +44,8 @@ describe("UserBulkCsvDownload", () => {
       </MockTheme>
     );
 
-    expect(screen.getByText("downloadCsvDes")).toBeInTheDocument();
-    expect(screen.getByText("downloadCsvButton")).toBeInTheDocument();
+    expect(screen.getByText("downloadExcelDes")).toBeInTheDocument();
+    expect(screen.getByText("downloadExcelButton")).toBeInTheDocument();
     expect(screen.getByText("nextButton")).toBeInTheDocument();
   });
 

--- a/frontend/src/community/people/components/molecules/UserBulkUploadModals/UserBulkCsvDownload.tsx
+++ b/frontend/src/community/people/components/molecules/UserBulkUploadModals/UserBulkCsvDownload.tsx
@@ -44,7 +44,7 @@ const UserBulkCsvDownload = () => {
   return (
     <div>
       <div>
-        <p className=" font-normal pb-6">{translateText(["downloadCsvDes"])}</p>
+        <p className=" font-normal pb-6">{translateText(["downloadExcelDes"])}</p>
         <div className="flex flex-row justify-end gap-3 mb-4">
           <a
             href={userBulkTemplate.url}
@@ -65,7 +65,7 @@ const UserBulkCsvDownload = () => {
               }
               iconPosition="end"
             >
-              {translateText(["downloadCsvButton"])}
+              {translateText(["downloadExcelButton"])}
             </ButtonV2>
           </a>
           <ButtonV2


### PR DESCRIPTION
## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/1010) 

### Summary

- update user bulk upload template description and button text to excel from csv

### How to test

1. Navigate to the People option in the main navigation bar.
2. Click on the Directory sub-menu option.
3. Click on the bulk upload button in the directory page.
4. In the Add People Modal, check the description text and download button text.
    it should display the text excel instead of csv.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [x] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [x] Pull request is raised from the correct source branch
- [x] Pull request is raised to the correct destination branch
- [x] Pull request is raised with correct title
- [x] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
