### PR TITLE
fix/time-comfiguration-page-accessibility-issues

### DIFF
--- a/frontend/src/community/common/components/molecules/DropdownList/DropdownList.tsx
+++ b/frontend/src/community/common/components/molecules/DropdownList/DropdownList.tsx
@@ -9,7 +9,7 @@ import {
 import { SelectChangeEvent } from "@mui/material/Select";
 import { Theme, useTheme } from "@mui/material/styles";
 import { Box, SxProps } from "@mui/system";
-import { FC, JSX, KeyboardEvent, SyntheticEvent } from "react";
+import { FC, JSX, KeyboardEvent, SyntheticEvent, useRef } from "react";
 
 import Icon from "~community/common/components/atoms/Icon/Icon";
 import Tooltip from "~community/common/components/atoms/Tooltip/Tooltip";
@@ -103,6 +103,7 @@ const DropdownList: FC<Props> = ({
 }: Props) => {
   const theme: Theme = useTheme();
   const classes = styles(theme);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const handleChange = (
     event:
@@ -116,6 +117,7 @@ const DropdownList: FC<Props> = ({
   return (
     <Box
       component="div"
+      ref={containerRef}
       sx={{ ...classes.componentStyle, ...componentStyle } as SxProps}
     >
       <Stack
@@ -172,6 +174,7 @@ const DropdownList: FC<Props> = ({
             disabled={isDisabled}
             multiple={isMultiValue}
             MenuProps={{
+              container: containerRef.current,
               style: {
                 maxHeight: 300,
                 zIndex: ZIndexEnums.NEWMODAL,

--- a/frontend/src/community/common/components/molecules/DropdownList/DropdownList.tsx
+++ b/frontend/src/community/common/components/molecules/DropdownList/DropdownList.tsx
@@ -9,7 +9,7 @@ import {
 import { SelectChangeEvent } from "@mui/material/Select";
 import { Theme, useTheme } from "@mui/material/styles";
 import { Box, SxProps } from "@mui/system";
-import { FC, JSX, KeyboardEvent, SyntheticEvent, useRef } from "react";
+import { FC, JSX, KeyboardEvent, SyntheticEvent } from "react";
 
 import Icon from "~community/common/components/atoms/Icon/Icon";
 import Tooltip from "~community/common/components/atoms/Tooltip/Tooltip";
@@ -65,6 +65,7 @@ interface Props {
   enableTextWrapping?: boolean;
   showSpinnerWhenNoData?: boolean;
   noOptionsText?: string;
+  container?: HTMLElement | null;
 }
 
 const DropdownList: FC<Props> = ({
@@ -99,11 +100,11 @@ const DropdownList: FC<Props> = ({
   typographyStyles,
   enableTextWrapping = false,
   showSpinnerWhenNoData = true,
-  noOptionsText
+  noOptionsText,
+  container
 }: Props) => {
   const theme: Theme = useTheme();
   const classes = styles(theme);
-  const containerRef = useRef<HTMLDivElement>(null);
 
   const handleChange = (
     event:
@@ -117,7 +118,6 @@ const DropdownList: FC<Props> = ({
   return (
     <Box
       component="div"
-      ref={containerRef}
       sx={{ ...classes.componentStyle, ...componentStyle } as SxProps}
     >
       <Stack
@@ -174,7 +174,7 @@ const DropdownList: FC<Props> = ({
             disabled={isDisabled}
             multiple={isMultiValue}
             MenuProps={{
-              container: containerRef.current,
+              ...(container ? { container: () => container } : {}),
               style: {
                 maxHeight: 300,
                 zIndex: ZIndexEnums.NEWMODAL,
@@ -295,6 +295,9 @@ const DropdownList: FC<Props> = ({
             name={inputName}
             disabled={isDisabled}
             multiple={isMultiValue}
+            MenuProps={{
+              ...(container ? { container: () => container } : {})
+            }}
             sx={{
               flex: 1,
               "&& .MuiInputBase-input": {

--- a/frontend/src/community/configurations/components/organisms/TimeConfigurations/TimeConfigurations.tsx
+++ b/frontend/src/community/configurations/components/organisms/TimeConfigurations/TimeConfigurations.tsx
@@ -10,7 +10,7 @@ import {
 import { ButtonV2 } from "@rootcodelabs/skapp-ui";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/router";
-import { JSX, useCallback, useEffect, useState } from "react";
+import { JSX, useCallback, useEffect, useRef, useState } from "react";
 
 import BasicChip from "~community/common/components/atoms/Chips/BasicChip/BasicChip";
 import Icon from "~community/common/components/atoms/Icon/Icon";
@@ -50,6 +50,7 @@ const TimeConfigurations = (): JSX.Element => {
   const theme: Theme = useTheme();
   const classes = styles();
   const translateText = useTranslator("configurations", "times");
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -304,7 +305,7 @@ const TimeConfigurations = (): JSX.Element => {
 
   return (
     <>
-      <Stack sx={classes.container}>
+      <Stack ref={containerRef} sx={classes.container}>
         <Stack sx={classes.sectionContainer}>
           <Typography sx={classes.sectionTitle}>
             {translateText(["globalSettingsTitle"]) ?? ""}
@@ -366,6 +367,7 @@ const TimeConfigurations = (): JSX.Element => {
                 setWeekStartDay(e.target.value)
               }
               componentStyle={{ mt: "0rem" }}
+              container={containerRef.current}
             />
           </Stack>
 
@@ -385,6 +387,7 @@ const TimeConfigurations = (): JSX.Element => {
               onChange={(e: SelectChangeEvent) => setStartTime(e.target.value)}
               componentStyle={{ mt: "0rem" }}
               ariaLabel={translateText(["startOfAWorkDayTitle"]) ?? ""}
+              container={containerRef.current}
             />
           </Stack>
         </Stack>
@@ -409,6 +412,7 @@ const TimeConfigurations = (): JSX.Element => {
             }
             componentStyle={classes.inputField}
             ariaLabel={translateText(["numberOfWorkHoursInADayTitle"]) ?? ""}
+            container={containerRef.current}
           />
 
           <Stack sx={classes.inputField}>


### PR DESCRIPTION
This pull request updates the `DropdownList` component to improve how the dropdown menu is anchored and rendered. The main enhancement is the introduction of a `ref` to the dropdown container, which is then used to specify the container for the dropdown menu, ensuring better positioning and integration with the parent component.

Enhancements to dropdown menu anchoring and rendering:

* Added a `useRef` hook (`containerRef`) to reference the dropdown's container div in `DropdownList.tsx`. [[1]](diffhunk://#diff-77e61a2c9b95b2500b8147163ceb616e35edc838476fb648fc3bd58f1a0f250eL12-R12) [[2]](diffhunk://#diff-77e61a2c9b95b2500b8147163ceb616e35edc838476fb648fc3bd58f1a0f250eR106)
* Passed `containerRef` to the `ref` prop of the main `<Box>` container, enabling direct access to the DOM node.
* Updated the `MenuProps` of the dropdown to set the `container` property to `containerRef.current`, ensuring the dropdown menu is rendered within the intended container.## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/[id]) 

### Summary

-

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
