### PR TITLE
feat: global string trimmer, test workflow, DB schema fixes, and config updates

### DIFF
--- a/.github/workflows/test-be.yml
+++ b/.github/workflows/test-be.yml
@@ -10,16 +10,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+        - name: Checkout code
+          uses: actions/checkout@v4
+          with:
+            path: skapp
         - name: Setup Java
           uses: actions/setup-java@v4
           with:
             distribution: 'temurin'
             java-version: '21'
             cache: maven
-        - name: Checkout code
-          uses: actions/checkout@v4
-          with:
-            path: skapp
         - name: Run tests
           run: |
             cd skapp/backend

--- a/.github/workflows/test-be.yml
+++ b/.github/workflows/test-be.yml
@@ -20,6 +20,7 @@ jobs:
             distribution: 'temurin'
             java-version: '21'
             cache: maven
+            cache-dependency-path: skapp/backend/pom.xml
         - name: Run tests
           run: |
             cd skapp/backend

--- a/.github/workflows/test-be.yml
+++ b/.github/workflows/test-be.yml
@@ -1,0 +1,33 @@
+name: Run Backend Tests
+
+on:
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+        - name: Setup Java
+          uses: actions/setup-java@v4
+          with:
+            distribution: 'temurin'
+            java-version: '21'
+            cache: maven
+        - name: Checkout code
+          uses: actions/checkout@v4
+          with:
+            path: skapp
+        - name: Run tests
+          run: |
+            cd skapp/backend
+            mvn -B test
+        - name: Upload test reports
+          if: always()
+          uses: actions/upload-artifact@v4
+          with:
+            name: test-reports
+            path: skapp/backend/target/surefire-reports/
+            retention-days: 7

--- a/backend/src/main/java/com/skapp/community/common/config/JacksonConfig.java
+++ b/backend/src/main/java/com/skapp/community/common/config/JacksonConfig.java
@@ -26,7 +26,7 @@ public class JacksonConfig {
 		@Override
 		public String deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
 				throws JacksonException {
-			String value = jsonParser.getValueAsString();
+			String value = jsonParser.getString();
 			return value != null ? value.trim() : null;
 		}
 

--- a/backend/src/main/java/com/skapp/community/common/config/JacksonConfig.java
+++ b/backend/src/main/java/com/skapp/community/common/config/JacksonConfig.java
@@ -1,0 +1,35 @@
+package com.skapp.community.common.config;
+
+import org.springframework.boot.jackson.autoconfigure.JsonMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.module.SimpleModule;
+
+@Configuration
+public class JacksonConfig {
+
+	@Bean
+	public JsonMapperBuilderCustomizer trimmingCustomizer() {
+		return builder -> {
+			SimpleModule module = new SimpleModule("StringTrimmingModule");
+			module.addDeserializer(String.class, new StringTrimmingDeserializer());
+			builder.addModule(module);
+		};
+	}
+
+	private static class StringTrimmingDeserializer extends ValueDeserializer<String> {
+
+		@Override
+		public String deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+				throws JacksonException {
+			String value = jsonParser.getValueAsString();
+			return value != null ? value.trim() : null;
+		}
+
+	}
+
+}

--- a/backend/src/main/java/com/skapp/community/crmplanner/payload/request/CrmCompanyCreateDto.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/payload/request/CrmCompanyCreateDto.java
@@ -1,15 +1,13 @@
 package com.skapp.community.crmplanner.payload.request;
 
-import com.skapp.enterprise.common.config.TrimmingStringDeserializer;
+import com.skapp.community.crmplanner.type.CrmIndustry;
 import lombok.Getter;
 import lombok.Setter;
-import tools.jackson.databind.annotation.JsonDeserialize;
 
 @Getter
 @Setter
 public class CrmCompanyCreateDto {
 
-	@JsonDeserialize(using = TrimmingStringDeserializer.class)
 	private String name;
 
 	private String industry;

--- a/backend/src/main/java/com/skapp/community/crmplanner/payload/request/CrmCompanyEditDto.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/payload/request/CrmCompanyEditDto.java
@@ -1,15 +1,13 @@
 package com.skapp.community.crmplanner.payload.request;
 
-import com.skapp.enterprise.common.config.TrimmingStringDeserializer;
+import com.skapp.community.crmplanner.type.CrmIndustry;
 import lombok.Getter;
 import lombok.Setter;
-import tools.jackson.databind.annotation.JsonDeserialize;
 
 @Getter
 @Setter
 public class CrmCompanyEditDto {
 
-	@JsonDeserialize(using = TrimmingStringDeserializer.class)
 	private String name;
 
 	private String industry;

--- a/backend/src/main/java/com/skapp/community/crmplanner/payload/request/CrmDealCreateRequestDto.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/payload/request/CrmDealCreateRequestDto.java
@@ -1,19 +1,16 @@
 package com.skapp.community.crmplanner.payload.request;
 
 import com.skapp.community.crmplanner.type.CrmDealPriority;
-import com.skapp.enterprise.common.config.TrimmingStringDeserializer;
 
 import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
-import tools.jackson.databind.annotation.JsonDeserialize;
 
 @Getter
 @Setter
 public class CrmDealCreateRequestDto {
 
-	@JsonDeserialize(using = TrimmingStringDeserializer.class)
 	private String name;
 
 	private String description;
@@ -24,7 +21,6 @@ public class CrmDealCreateRequestDto {
 
 	private LocalDateTime closingAt;
 
-	@JsonDeserialize(using = TrimmingStringDeserializer.class)
 	private String amount;
 
 	private Long companyId;

--- a/backend/src/main/resources/application-non-prd.yml
+++ b/backend/src/main/resources/application-non-prd.yml
@@ -65,6 +65,9 @@ jwt:
     short-duration:
       expiration-time: 21600000 # Expiration time in milliseconds (6 hours)
 
+domain:
+  base: ${DOMAIN_BASE:localhost}
+
 encryptDecryptAlgorithm:
   secret: ${ENCRYPT_DECRYPT_SECRET}
 

--- a/backend/src/main/resources/application-prd.yml
+++ b/backend/src/main/resources/application-prd.yml
@@ -61,5 +61,8 @@ jwt:
     short-duration:
       expiration-time: 21600000 # Expiration time in milliseconds (6 hours)
 
+domain:
+  base: ${DOMAIN_BASE}
+
 encryptDecryptAlgorithm:
   secret: ${ENCRYPT_DECRYPT_SECRET}

--- a/backend/src/main/resources/community/db/changelog/db.changelog.yml
+++ b/backend/src/main/resources/community/db/changelog/db.changelog.yml
@@ -35,4 +35,5 @@ databaseChangeLog:
   - include:
       file: classpath:community/db/changelog/ddl-script/people-ddl-script-v1-create_shr_com_work_location_ppl_holiday_table.sql
   - include:
-      file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-add-pm-invoice-roles.sql
+      file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-create-table-module-roles-restriction.sql
+

--- a/backend/src/main/resources/community/db/changelog/db.changelog.yml
+++ b/backend/src/main/resources/community/db/changelog/db.changelog.yml
@@ -25,8 +25,6 @@ databaseChangeLog:
   - include:
       file: classpath:community/db/changelog/ddl-script/people-ddl-script-v1-add-employee-title.sql
   - include:
-      file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-alter-table-module-config-add-column-crm-module.sql
-  - include:
       file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-alter-table-employee-role-add-column-crm-role.sql
   - include:
       file: classpath:community/db/changelog/ddl-script/common-dml-script-v1-update-employee-role-set-crm-role.sql

--- a/backend/src/main/resources/community/db/changelog/db.changelog.yml
+++ b/backend/src/main/resources/community/db/changelog/db.changelog.yml
@@ -36,4 +36,6 @@ databaseChangeLog:
       file: classpath:community/db/changelog/ddl-script/people-ddl-script-v1-create_shr_com_work_location_ppl_holiday_table.sql
   - include:
       file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-create-table-module-roles-restriction.sql
+  - include:
+      file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-alter-table-notification-add-is-type-viewed.sql
 

--- a/backend/src/main/resources/community/db/changelog/db.changelog.yml
+++ b/backend/src/main/resources/community/db/changelog/db.changelog.yml
@@ -31,6 +31,8 @@ databaseChangeLog:
   - include:
       file: classpath:community/db/changelog/ddl-script/people-ddl-script-v1-create-table-com-work-location.sql
   - include:
+      file: classpath:community/db/changelog/ddl-script/people-ddl-script-v1-alter-table-employee-add-work-location-id.sql
+  - include:
       file: classpath:community/db/changelog/ddl-script/people-ddl-script-v1-create_shr_com_work_location_ppl_holiday_table.sql
   - include:
       file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-add-pm-invoice-roles.sql

--- a/backend/src/main/resources/community/db/changelog/db.changelog.yml
+++ b/backend/src/main/resources/community/db/changelog/db.changelog.yml
@@ -29,6 +29,8 @@ databaseChangeLog:
   - include:
       file: classpath:community/db/changelog/ddl-script/common-dml-script-v1-update-employee-role-set-crm-role.sql
   - include:
+      file: classpath:community/db/changelog/ddl-script/people-ddl-script-v1-create-table-com-work-location.sql
+  - include:
       file: classpath:community/db/changelog/ddl-script/people-ddl-script-v1-create_shr_com_work_location_ppl_holiday_table.sql
   - include:
       file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-add-pm-invoice-roles.sql

--- a/backend/src/main/resources/community/db/changelog/ddl-script/common-ddl-script-v1-alter-table-module-config-add-column-crm-module.sql
+++ b/backend/src/main/resources/community/db/changelog/ddl-script/common-ddl-script-v1-alter-table-module-config-add-column-crm-module.sql
@@ -1,7 +1,0 @@
--- liquibase formatted sql
-
--- changeset anusham:common-ddl-script-v1-alter-table-module-config-add-column-crm-module
-ALTER TABLE `module_config`
-    ADD COLUMN `crm_module` bit(1) DEFAULT b'1';
-
--- rollback ALTER TABLE `module_config` DROP COLUMN `crm_module`;

--- a/backend/src/main/resources/community/db/changelog/ddl-script/common-ddl-script-v1-alter-table-notification-add-is-type-viewed.sql
+++ b/backend/src/main/resources/community/db/changelog/ddl-script/common-ddl-script-v1-alter-table-notification-add-is-type-viewed.sql
@@ -1,0 +1,7 @@
+-- liquibase formatted sql
+
+-- changeset thusala:common-ddl-script-v1-alter-table-notification-add-column-is-type-viewed
+ALTER TABLE `notification`
+    ADD COLUMN `is_type_viewed` BOOLEAN NOT NULL DEFAULT 0;
+
+-- rollback ALTER TABLE `notification` DROP COLUMN `is_type_viewed`;

--- a/backend/src/main/resources/community/db/changelog/ddl-script/common-ddl-script-v1-create-table-module-roles-restriction.sql
+++ b/backend/src/main/resources/community/db/changelog/ddl-script/common-ddl-script-v1-create-table-module-roles-restriction.sql
@@ -1,0 +1,11 @@
+-- liquibase formatted sql
+
+-- changeset shakila:00081_create_table_module_roles_restriction
+CREATE TABLE IF NOT EXISTS `module_roles_restriction`
+(
+    `module`       VARCHAR(255) NOT NULL,
+    `restrictions` VARCHAR(255) DEFAULT NULL,
+    PRIMARY KEY (`module`)
+);
+
+-- rollback DROP TABLE `module_roles_restriction`;

--- a/backend/src/main/resources/community/db/changelog/ddl-script/people-ddl-script-v1-alter-table-employee-add-work-location-id.sql
+++ b/backend/src/main/resources/community/db/changelog/ddl-script/people-ddl-script-v1-alter-table-employee-add-work-location-id.sql
@@ -1,0 +1,8 @@
+-- liquibase formatted sql
+
+-- changeset AkilaSilva:people-ddl-script-v1-alter-table-employee-add-work-location-id
+ALTER TABLE `employee`
+    ADD COLUMN `work_location_id` bigint DEFAULT NULL,
+    ADD CONSTRAINT `FK_employee_work_location` FOREIGN KEY (`work_location_id`) REFERENCES `com_work_location` (`id`);
+
+-- rollback ALTER TABLE `employee` DROP FOREIGN KEY `FK_employee_work_location`, DROP COLUMN `work_location_id`;

--- a/backend/src/main/resources/community/db/changelog/ddl-script/people-ddl-script-v1-create-table-com-work-location.sql
+++ b/backend/src/main/resources/community/db/changelog/ddl-script/people-ddl-script-v1-create-table-com-work-location.sql
@@ -1,0 +1,16 @@
+-- liquibase formatted sql
+
+-- changeset AkilaSilva:people-ddl-script-v1-create-table-com-work-location
+CREATE TABLE IF NOT EXISTS `com_work_location`
+(
+    `id`                 bigint      NOT NULL AUTO_INCREMENT,
+    `name`               text        NOT NULL,
+    `address`            text                 DEFAULT NULL,
+    `created_by`         text                 DEFAULT NULL,
+    `created_date`       datetime(6)          DEFAULT NULL,
+    `last_modified_by`   text                 DEFAULT NULL,
+    `last_modified_date` datetime(6)          DEFAULT NULL,
+    PRIMARY KEY (`id`)
+);
+
+-- rollback DROP TABLE `com_work_location`;

--- a/backend/src/test/java/com/skapp/community/timeplanner/controller/v1/TimeControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/timeplanner/controller/v1/TimeControllerIntegrationTest.java
@@ -130,8 +130,8 @@ class TimeControllerIntegrationTest {
 	class TimeRecordTests {
 
 		@Test
-		@DisplayName("Add time log for current day with CLOCK_IN - Returns OK")
-		void addTimeLog_ForTheCurrentDay_CLOCK_IN_ReturnsHttpStatusOk() throws Exception {
+		@DisplayName("Add time log for current day with CLOCK_IN - Returns Created")
+		void addTimeLog_ForTheCurrentDay_CLOCK_IN_ReturnsHttpStatusCreated() throws Exception {
 			LocalDateTime startTime = DateTimeUtils.getCurrentUtcDateTime().minusDays(1L);
 			AddTimeRecordDto addTimeRecordDto = new AddTimeRecordDto();
 			addTimeRecordDto.setRecordActionType(TimeRecordActionTypes.START);

--- a/backend/src/test/java/com/skapp/community/timeplanner/controller/v1/TimeControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/timeplanner/controller/v1/TimeControllerIntegrationTest.java
@@ -138,7 +138,7 @@ class TimeControllerIntegrationTest {
 			addTimeRecordDto.setTime(startTime);
 
 			performPostRequest(BASE_PATH + "/record", addTimeRecordDto).andDo(print())
-				.andExpect(status().isOk())
+				.andExpect(status().isCreated())
 				.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
 				.andExpect(jsonPath(RESULTS_0_PATH).value(messageUtil.getMessage(
 						TimeMessageConstant.TIME_SUCCESS_TIME_RECORD_ADDED, new Object[] { startTime, "START" })));

--- a/backend/src/test/java/com/skapp/support/TestConstants.java
+++ b/backend/src/test/java/com/skapp/support/TestConstants.java
@@ -1,6 +1,5 @@
 package com.skapp.support;
 
-import com.skapp.enterprise.common.constant.EpAuthConstants;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -19,10 +18,5 @@ public class TestConstants {
 	public static final String STATUS_SUCCESSFUL = "successful";
 
 	public static final String STATUS_UNSUCCESSFUL = "unsuccessful";
-
-	// Auth constants (single source of truth: EpAuthConstants)
-	public static final String API_KEY_HEADER = EpAuthConstants.API_KEY_HEADER;
-
-	public static final String VALID_API_KEY = "test-api-key-12345";
 
 }


### PR DESCRIPTION
## Changes

Cherry-picked from develop (PR #1426) — only our changes:

- **Global String Trimmer**: Added \JacksonConfig\ with \JsonMapperBuilderCustomizer\ that trims all incoming string values globally. Removed per-field \@JsonDeserialize\ from CRM DTOs.
- **Test Workflow**: Added \	est-be.yml\ GitHub Actions workflow to run \mvn test\ on PRs as a separate check.
- **Test Fix**: Fixed \TimeControllerIntegrationTest\ to expect 201 CREATED.
- **DB Schema Fixes**: Added missing Liquibase scripts for \com_work_location\, \work_location_id\ column, \module_roles_restriction\, \is_type_viewed\ column. Removed enterprise-only \module_config\ script.
- **Config**: Added \domain.base\ property to non-prd and prd configs.
- **TestConstants**: Moved enterprise API key constants to \EpTestConstants\.

**Related PRs:**
- #1426 (develop)
- rootcodelabs/skapp-ep-be-src#676
- rootcodelabs/skapp-ep-be-tests#19