### PR TITLE
feat: global string trimmer, test workflow, DB schema fixes, and config updates

### DIFF
--- a/.github/workflows/test-be.yml
+++ b/.github/workflows/test-be.yml
@@ -1,0 +1,34 @@
+name: Run Backend Tests
+
+on:
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+        - name: Checkout code
+          uses: actions/checkout@v4
+          with:
+            path: skapp
+        - name: Setup Java
+          uses: actions/setup-java@v4
+          with:
+            distribution: 'temurin'
+            java-version: '21'
+            cache: maven
+            cache-dependency-path: skapp/backend/pom.xml
+        - name: Run tests
+          run: |
+            cd skapp/backend
+            mvn -B test
+        - name: Upload test reports
+          if: always()
+          uses: actions/upload-artifact@v4
+          with:
+            name: test-reports
+            path: skapp/backend/target/surefire-reports/
+            retention-days: 7

--- a/backend/src/main/java/com/skapp/community/common/config/JacksonConfig.java
+++ b/backend/src/main/java/com/skapp/community/common/config/JacksonConfig.java
@@ -26,7 +26,7 @@ public class JacksonConfig {
 		@Override
 		public String deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
 				throws JacksonException {
-			String value = jsonParser.getString();
+			String value = jsonParser.getValueAsString();
 			return value != null ? value.trim() : null;
 		}
 

--- a/backend/src/main/java/com/skapp/community/common/config/JacksonConfig.java
+++ b/backend/src/main/java/com/skapp/community/common/config/JacksonConfig.java
@@ -1,0 +1,35 @@
+package com.skapp.community.common.config;
+
+import org.springframework.boot.jackson.autoconfigure.JsonMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.module.SimpleModule;
+
+@Configuration
+public class JacksonConfig {
+
+	@Bean
+	public JsonMapperBuilderCustomizer trimmingCustomizer() {
+		return builder -> {
+			SimpleModule module = new SimpleModule("StringTrimmingModule");
+			module.addDeserializer(String.class, new StringTrimmingDeserializer());
+			builder.addModule(module);
+		};
+	}
+
+	private static class StringTrimmingDeserializer extends ValueDeserializer<String> {
+
+		@Override
+		public String deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+				throws JacksonException {
+			String value = jsonParser.getString();
+			return value != null ? value.trim() : null;
+		}
+
+	}
+
+}

--- a/backend/src/main/java/com/skapp/community/common/repository/OrganizationConfigDao.java
+++ b/backend/src/main/java/com/skapp/community/common/repository/OrganizationConfigDao.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import java.util.Optional;
 
 public interface OrganizationConfigDao
-		extends JpaRepository<OrganizationConfig, Long>, JpaSpecificationExecutor<OrganizationConfig> {
+		extends JpaRepository<OrganizationConfig, String>, JpaSpecificationExecutor<OrganizationConfig> {
 
 	Optional<OrganizationConfig> findOrganizationConfigByOrganizationConfigType(String organizationConfigType);
 

--- a/backend/src/main/java/com/skapp/community/crmplanner/payload/request/CrmCompanyCreateDto.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/payload/request/CrmCompanyCreateDto.java
@@ -1,15 +1,12 @@
 package com.skapp.community.crmplanner.payload.request;
 
-import com.skapp.enterprise.common.config.TrimmingStringDeserializer;
 import lombok.Getter;
 import lombok.Setter;
-import tools.jackson.databind.annotation.JsonDeserialize;
 
 @Getter
 @Setter
 public class CrmCompanyCreateDto {
 
-	@JsonDeserialize(using = TrimmingStringDeserializer.class)
 	private String name;
 
 	private String industry;

--- a/backend/src/main/java/com/skapp/community/crmplanner/payload/request/CrmCompanyEditDto.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/payload/request/CrmCompanyEditDto.java
@@ -1,15 +1,12 @@
 package com.skapp.community.crmplanner.payload.request;
 
-import com.skapp.enterprise.common.config.TrimmingStringDeserializer;
 import lombok.Getter;
 import lombok.Setter;
-import tools.jackson.databind.annotation.JsonDeserialize;
 
 @Getter
 @Setter
 public class CrmCompanyEditDto {
 
-	@JsonDeserialize(using = TrimmingStringDeserializer.class)
 	private String name;
 
 	private String industry;

--- a/backend/src/main/java/com/skapp/community/crmplanner/payload/request/CrmDealCreateRequestDto.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/payload/request/CrmDealCreateRequestDto.java
@@ -1,19 +1,16 @@
 package com.skapp.community.crmplanner.payload.request;
 
 import com.skapp.community.crmplanner.type.CrmDealPriority;
-import com.skapp.enterprise.common.config.TrimmingStringDeserializer;
 
 import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
-import tools.jackson.databind.annotation.JsonDeserialize;
 
 @Getter
 @Setter
 public class CrmDealCreateRequestDto {
 
-	@JsonDeserialize(using = TrimmingStringDeserializer.class)
 	private String name;
 
 	private String description;
@@ -24,7 +21,6 @@ public class CrmDealCreateRequestDto {
 
 	private LocalDateTime closingAt;
 
-	@JsonDeserialize(using = TrimmingStringDeserializer.class)
 	private String amount;
 
 	private Long companyId;

--- a/backend/src/main/resources/application-non-prd.yml
+++ b/backend/src/main/resources/application-non-prd.yml
@@ -65,8 +65,8 @@ jwt:
     short-duration:
       expiration-time: 21600000 # Expiration time in milliseconds (6 hours)
 
-encryptDecryptAlgorithm:
-  secret: ${ENCRYPT_DECRYPT_SECRET}
-
 domain:
   base: ${DOMAIN_BASE:localhost}
+
+encryptDecryptAlgorithm:
+  secret: ${ENCRYPT_DECRYPT_SECRET}

--- a/backend/src/main/resources/application-prd.yml
+++ b/backend/src/main/resources/application-prd.yml
@@ -61,5 +61,8 @@ jwt:
     short-duration:
       expiration-time: 21600000 # Expiration time in milliseconds (6 hours)
 
+domain:
+  base: ${DOMAIN_BASE}
+
 encryptDecryptAlgorithm:
   secret: ${ENCRYPT_DECRYPT_SECRET}

--- a/backend/src/main/resources/community/db/changelog/db.changelog.yml
+++ b/backend/src/main/resources/community/db/changelog/db.changelog.yml
@@ -18,19 +18,23 @@ databaseChangeLog:
   - include:
       file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-edit-employeerole.sql
   - include:
-      file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-create-table-company-objective.sql
+      file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-add-pm-invoice-roles.sql
   - include:
       file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-add-user-lang.sql
   - include:
-  - include:
       file: classpath:community/db/changelog/ddl-script/people-ddl-script-v1-add-employee-title.sql
-  - include:
-      file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-alter-table-module-config-add-column-crm-module.sql
   - include:
       file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-alter-table-employee-role-add-column-crm-role.sql
   - include:
       file: classpath:community/db/changelog/ddl-script/common-dml-script-v1-update-employee-role-set-crm-role.sql
   - include:
+      file: classpath:community/db/changelog/ddl-script/people-ddl-script-v1-create-table-com-work-location.sql
+  - include:
+      file: classpath:community/db/changelog/ddl-script/people-ddl-script-v1-alter-table-employee-add-work-location-id.sql
+  - include:
       file: classpath:community/db/changelog/ddl-script/people-ddl-script-v1-create_shr_com_work_location_ppl_holiday_table.sql
   - include:
-      file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-add-pm-invoice-roles.sql
+      file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-create-table-module-roles-restriction.sql
+  - include:
+      file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-alter-table-notification-add-is-type-viewed.sql
+

--- a/backend/src/main/resources/community/db/changelog/db.changelog.yml
+++ b/backend/src/main/resources/community/db/changelog/db.changelog.yml
@@ -39,4 +39,6 @@ databaseChangeLog:
       file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-create-table-module-roles-restriction.sql
   - include:
       file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-alter-table-notification-add-is-type-viewed.sql
+  - include:
+      file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-create-table-company-objective.sql
 

--- a/backend/src/main/resources/community/db/changelog/db.changelog.yml
+++ b/backend/src/main/resources/community/db/changelog/db.changelog.yml
@@ -18,19 +18,25 @@ databaseChangeLog:
   - include:
       file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-edit-employeerole.sql
   - include:
-      file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-create-table-company-objective.sql
+      file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-add-pm-invoice-roles.sql
   - include:
       file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-add-user-lang.sql
   - include:
-  - include:
       file: classpath:community/db/changelog/ddl-script/people-ddl-script-v1-add-employee-title.sql
-  - include:
-      file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-alter-table-module-config-add-column-crm-module.sql
   - include:
       file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-alter-table-employee-role-add-column-crm-role.sql
   - include:
       file: classpath:community/db/changelog/ddl-script/common-dml-script-v1-update-employee-role-set-crm-role.sql
   - include:
+      file: classpath:community/db/changelog/ddl-script/people-ddl-script-v1-create-table-com-work-location.sql
+  - include:
+      file: classpath:community/db/changelog/ddl-script/people-ddl-script-v1-alter-table-employee-add-work-location-id.sql
+  - include:
+      file: classpath:community/db/changelog/ddl-script/people-ddl-script-v1-create-table-com-work-location-geofence.sql
+  - include:
       file: classpath:community/db/changelog/ddl-script/people-ddl-script-v1-create_shr_com_work_location_ppl_holiday_table.sql
   - include:
-      file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-add-pm-invoice-roles.sql
+      file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-create-table-module-roles-restriction.sql
+  - include:
+      file: classpath:community/db/changelog/ddl-script/common-ddl-script-v1-alter-table-notification-add-is-type-viewed.sql
+

--- a/backend/src/main/resources/community/db/changelog/ddl-script/common-ddl-script-v1-alter-table-module-config-add-column-crm-module.sql
+++ b/backend/src/main/resources/community/db/changelog/ddl-script/common-ddl-script-v1-alter-table-module-config-add-column-crm-module.sql
@@ -1,7 +1,0 @@
--- liquibase formatted sql
-
--- changeset anusham:common-ddl-script-v1-alter-table-module-config-add-column-crm-module
-ALTER TABLE `module_config`
-    ADD COLUMN `crm_module` bit(1) DEFAULT b'1';
-
--- rollback ALTER TABLE `module_config` DROP COLUMN `crm_module`;

--- a/backend/src/main/resources/community/db/changelog/ddl-script/common-ddl-script-v1-alter-table-notification-add-is-type-viewed.sql
+++ b/backend/src/main/resources/community/db/changelog/ddl-script/common-ddl-script-v1-alter-table-notification-add-is-type-viewed.sql
@@ -1,0 +1,7 @@
+-- liquibase formatted sql
+
+-- changeset thusala:common-ddl-script-v1-alter-table-notification-add-column-is-type-viewed
+ALTER TABLE `notification`
+    ADD COLUMN `is_type_viewed` BOOLEAN NOT NULL DEFAULT 0;
+
+-- rollback ALTER TABLE `notification` DROP COLUMN `is_type_viewed`;

--- a/backend/src/main/resources/community/db/changelog/ddl-script/common-ddl-script-v1-create-table-module-roles-restriction.sql
+++ b/backend/src/main/resources/community/db/changelog/ddl-script/common-ddl-script-v1-create-table-module-roles-restriction.sql
@@ -1,0 +1,11 @@
+-- liquibase formatted sql
+
+-- changeset shakila:00081_create_table_module_roles_restriction
+CREATE TABLE IF NOT EXISTS `module_roles_restriction`
+(
+    `module`       VARCHAR(255) NOT NULL,
+    `restrictions` VARCHAR(255) DEFAULT NULL,
+    PRIMARY KEY (`module`)
+);
+
+-- rollback DROP TABLE `module_roles_restriction`;

--- a/backend/src/main/resources/community/db/changelog/ddl-script/people-ddl-script-v1-alter-table-employee-add-work-location-id.sql
+++ b/backend/src/main/resources/community/db/changelog/ddl-script/people-ddl-script-v1-alter-table-employee-add-work-location-id.sql
@@ -1,0 +1,8 @@
+-- liquibase formatted sql
+
+-- changeset AkilaSilva:people-ddl-script-v1-alter-table-employee-add-work-location-id
+ALTER TABLE `employee`
+    ADD COLUMN `work_location_id` bigint DEFAULT NULL,
+    ADD CONSTRAINT `FK_employee_work_location` FOREIGN KEY (`work_location_id`) REFERENCES `com_work_location` (`id`);
+
+-- rollback ALTER TABLE `employee` DROP FOREIGN KEY `FK_employee_work_location`, DROP COLUMN `work_location_id`;

--- a/backend/src/main/resources/community/db/changelog/ddl-script/people-ddl-script-v1-create-table-com-work-location-geofence.sql
+++ b/backend/src/main/resources/community/db/changelog/ddl-script/people-ddl-script-v1-create-table-com-work-location-geofence.sql
@@ -1,0 +1,19 @@
+-- liquibase formatted sql
+
+-- changeset AkilaSilva:people-ddl-script-v1-create-table-com-work-location-geofence
+CREATE TABLE IF NOT EXISTS `com_work_location_geofence`
+(
+    `id`                 bigint NOT NULL AUTO_INCREMENT,
+    `work_location_id`   bigint NOT NULL,
+    `latitude`           text   NOT NULL,
+    `longitude`          text   NOT NULL,
+    `radius_meters`      int    NOT NULL,
+    `created_by`         text        DEFAULT NULL,
+    `created_date`       datetime(6) DEFAULT NULL,
+    `last_modified_by`   text        DEFAULT NULL,
+    `last_modified_date` datetime(6) DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    CONSTRAINT `FK_com_work_location_geofence_com_work_location_id` FOREIGN KEY (`work_location_id`) REFERENCES `com_work_location` (`id`) ON DELETE CASCADE
+);
+
+-- rollback DROP TABLE `com_work_location_geofence`;

--- a/backend/src/main/resources/community/db/changelog/ddl-script/people-ddl-script-v1-create-table-com-work-location-geofence.sql
+++ b/backend/src/main/resources/community/db/changelog/ddl-script/people-ddl-script-v1-create-table-com-work-location-geofence.sql
@@ -1,0 +1,20 @@
+-- liquibase formatted sql
+
+-- changeset AkilaSilva:people-ddl-script-v1-create-table-com-work-location-geofence
+CREATE TABLE IF NOT EXISTS `com_work_location_geofence`
+(
+    `id`                 bigint      NOT NULL AUTO_INCREMENT,
+    `work_location_id`   bigint      NOT NULL,
+    `latitude`           text        NOT NULL,
+    `longitude`          text        NOT NULL,
+    `radius_meters`      int         NOT NULL,
+    `created_by`         text                 DEFAULT NULL,
+    `created_date`       datetime(6)          DEFAULT NULL,
+    `last_modified_by`   text                 DEFAULT NULL,
+    `last_modified_date` datetime(6)          DEFAULT NULL,
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `UK_com_work_location_geofence_work_location_id` (`work_location_id`),
+    CONSTRAINT `FK_com_work_location_geofence_work_location_id` FOREIGN KEY (`work_location_id`) REFERENCES `com_work_location` (`id`)
+);
+
+-- rollback DROP TABLE `com_work_location_geofence`;

--- a/backend/src/main/resources/community/db/changelog/ddl-script/people-ddl-script-v1-create-table-com-work-location.sql
+++ b/backend/src/main/resources/community/db/changelog/ddl-script/people-ddl-script-v1-create-table-com-work-location.sql
@@ -1,0 +1,16 @@
+-- liquibase formatted sql
+
+-- changeset AkilaSilva:people-ddl-script-v1-create-table-com-work-location
+CREATE TABLE IF NOT EXISTS `com_work_location`
+(
+    `id`                 bigint      NOT NULL AUTO_INCREMENT,
+    `name`               text        NOT NULL,
+    `address`            text                 DEFAULT NULL,
+    `created_by`         text                 DEFAULT NULL,
+    `created_date`       datetime(6)          DEFAULT NULL,
+    `last_modified_by`   text                 DEFAULT NULL,
+    `last_modified_date` datetime(6)          DEFAULT NULL,
+    PRIMARY KEY (`id`)
+);
+
+-- rollback DROP TABLE `com_work_location`;

--- a/backend/src/test/java/com/skapp/support/TestConstants.java
+++ b/backend/src/test/java/com/skapp/support/TestConstants.java
@@ -1,6 +1,5 @@
 package com.skapp.support;
 
-import com.skapp.enterprise.common.constant.EpAuthConstants;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
@@ -19,10 +18,5 @@ public class TestConstants {
 	public static final String STATUS_SUCCESSFUL = "successful";
 
 	public static final String STATUS_UNSUCCESSFUL = "unsuccessful";
-
-	// Auth constants (single source of truth: EpAuthConstants)
-	public static final String API_KEY_HEADER = EpAuthConstants.API_KEY_HEADER;
-
-	public static final String VALID_API_KEY = "test-api-key-12345";
 
 }


### PR DESCRIPTION
## Changes

- **Global String Trimmer**: Added \JacksonConfig\ with \JsonMapperBuilderCustomizer\ that trims all incoming string values globally. Removed per-field \@JsonDeserialize\ from CRM DTOs.
- **Test Workflow**: Added \	est-be.yml\ GitHub Actions workflow to run \mvn test\ on PRs.
- **DB Schema Fixes**: Added missing Liquibase scripts for \com_work_location\, \work_location_id\ column, \module_roles_restriction\, \is_type_viewed\ column. Removed enterprise-only \module_config\ script.
- **Config**: Added \domain.base\ property to non-prd and prd configs.
- **TestConstants**: Removed enterprise API key constants (moved to \EpTestConstants\ in tests submodule).

**Related PRs:**
- #1426 (develop)
- rootcodelabs/skapp-ep-be-src#676
- rootcodelabs/skapp-ep-be-tests#19

Supersedes #1429 (which had build issues).