### PR TITLE
feat: add CRM access control for Representative role in getDrawerRoutes

### DIFF
--- a/frontend/src/community/common/utils/getDrawerRoutes.ts
+++ b/frontend/src/community/common/utils/getDrawerRoutes.ts
@@ -4,6 +4,7 @@ import {
   AdminTypes,
   EmployeeTypes,
   ManagerTypes,
+  RepresentativeTypes,
   SenderTypes,
   SuperAdminType
 } from "~community/common/types/AuthTypes";
@@ -11,7 +12,12 @@ import routes from "~community/common/utils/data/routes";
 import getEnterpriseDrawerRoutes from "~community/common/utils/getEnterpriseDrawerRoutes";
 import { TierEnum } from "~enterprise/common/enums/Common";
 
-type Role = AdminTypes | ManagerTypes | EmployeeTypes | SuperAdminType;
+type Role =
+  | AdminTypes
+  | ManagerTypes
+  | EmployeeTypes
+  | SuperAdminType
+  | RepresentativeTypes;
 
 type RouteWithBadge = { badge?: string };
 
@@ -231,6 +237,16 @@ const getDrawerRoutes = ({
         );
 
         if (!isInvoiceManager) {
+          return null;
+        }
+      }
+
+      if (route?.name === "CRM") {
+        const hasCRMAccess = userRoles?.includes(
+          RepresentativeTypes.CRM_SALES_REPRESENTATIVE
+        );
+
+        if (!hasCRMAccess) {
           return null;
         }
       }

--- a/frontend/src/community/common/utils/getEnterpriseDrawerRoutes.ts
+++ b/frontend/src/community/common/utils/getEnterpriseDrawerRoutes.ts
@@ -3,6 +3,7 @@ import {
   AdminTypes,
   EmployeeTypes,
   ManagerTypes,
+  RepresentativeTypes,
   SuperAdminType
 } from "~community/common/types/AuthTypes";
 
@@ -10,7 +11,12 @@ import { GlobalLoginMethod } from "../enums/CommonEnums";
 import { IconName } from "../types/IconTypes";
 import routes from "./data/routes";
 
-type Role = AdminTypes | ManagerTypes | EmployeeTypes | SuperAdminType;
+type Role =
+  | AdminTypes
+  | ManagerTypes
+  | EmployeeTypes
+  | SuperAdminType
+  | RepresentativeTypes;
 
 interface Props {
   userRoles: Role[] | undefined;


### PR DESCRIPTION
**Title:** `feat: hide CRM nav item when CRM module is disabled`

**Description:**

Added CRM module visibility guard to the sidebar navigation.

Previously, the CRM route had no role-based guard in getDrawerRoutes.ts, causing it to remain visible in the sidebar for all authorized users (including Super Admin) even when the CRM module was disabled from Organization Settings.

**Changes:**
- Imported `RepresentativeTypes` and added it to the `Role` union type
- Added a CRM block that returns `null` when the user does not have `ROLE_CRM_SALES_REPRESENTATIVE`, consistent with how other optional modules (Leave, Timesheet, Invoices, Sign, Projects) are handled

**Behavior:**
- CRM module **enabled** → CRM nav visible for users with any CRM role (`CRM_ADMIN`, `CRM_SALES_MANAGER`, `CRM_SALES_REPRESENTATIVE`)
- CRM module **disabled** → CRM nav hidden for all users (backend strips all CRM roles from the token via `EpAuthorityServiceImpl`)