### PR TITLE
fix: add 300ms debounce on employee ID lookup to prevent API abuse

### DIFF
--- a/frontend/src/community/people/components/organisms/AddNewResourceFlow/EmploymentDetailsSection/EmploymentDetailsSection.tsx
+++ b/frontend/src/community/people/components/organisms/AddNewResourceFlow/EmploymentDetailsSection/EmploymentDetailsSection.tsx
@@ -25,7 +25,9 @@ import MultiSelectChipInput from "~community/common/components/molecules/MultiSe
 import MultivalueDropdownList from "~community/common/components/molecules/MultiValueDropdownList/MultivalueDropdownList";
 import PeopleLayout from "~community/common/components/templates/PeopleLayout/PeopleLayout";
 import { LONG_DATE_TIME_FORMAT } from "~community/common/constants/timeConstants";
+import useDebounce from "~community/common/hooks/useDebounce";
 import { useTranslator } from "~community/common/hooks/useTranslator";
+import { EMPLOYEE_ID_LOOKUP_DEBOUNCE_MS } from "~community/people/constants/stringConstants";
 import { allowsAlphaNumericWithHyphenAndUnderscore } from "~community/common/regex/regexPatterns";
 import { ManagerTypes } from "~community/common/types/AuthTypes";
 import { DropdownListType } from "~community/common/types/CommonTypes";
@@ -238,13 +240,16 @@ const EmploymentDetailsSection = forwardRef<FormMethods, Props>(
     }));
 
     const { values, errors, setFieldValue, setFieldError } = formik;
+    const debouncedWorkEmail = useDebounce(values.workEmail, EMPLOYEE_ID_LOOKUP_DEBOUNCE_MS);
+    const debouncedEmployeeNumber = useDebounce(values.employeeNumber, EMPLOYEE_ID_LOOKUP_DEBOUNCE_MS);
+
     const {
       data: checkEmailAndIdentificationNo,
       refetch,
       isSuccess
     } = useCheckEmailAndIdentificationNo(
-      values.workEmail,
-      values.employeeNumber
+      debouncedWorkEmail,
+      debouncedEmployeeNumber
     );
 
     useEffect(() => {
@@ -495,7 +500,7 @@ const EmploymentDetailsSection = forwardRef<FormMethods, Props>(
         void refetch();
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [values.workEmail, values.employeeNumber]);
+    }, [debouncedWorkEmail, debouncedEmployeeNumber]);
 
     useEffect(() => {
       if (values.joinedDate) {

--- a/frontend/src/community/people/components/organisms/AddNewResourceFlow/EmploymentDetailsSection/EmploymentDetailsSection.tsx
+++ b/frontend/src/community/people/components/organisms/AddNewResourceFlow/EmploymentDetailsSection/EmploymentDetailsSection.tsx
@@ -27,7 +27,6 @@ import PeopleLayout from "~community/common/components/templates/PeopleLayout/Pe
 import { LONG_DATE_TIME_FORMAT } from "~community/common/constants/timeConstants";
 import useDebounce from "~community/common/hooks/useDebounce";
 import { useTranslator } from "~community/common/hooks/useTranslator";
-import { EMPLOYEE_ID_LOOKUP_DEBOUNCE_MS } from "~community/people/constants/stringConstants";
 import { allowsAlphaNumericWithHyphenAndUnderscore } from "~community/common/regex/regexPatterns";
 import { ManagerTypes } from "~community/common/types/AuthTypes";
 import { DropdownListType } from "~community/common/types/CommonTypes";
@@ -240,8 +239,8 @@ const EmploymentDetailsSection = forwardRef<FormMethods, Props>(
     }));
 
     const { values, errors, setFieldValue, setFieldError } = formik;
-    const debouncedWorkEmail = useDebounce(values.workEmail, EMPLOYEE_ID_LOOKUP_DEBOUNCE_MS);
-    const debouncedEmployeeNumber = useDebounce(values.employeeNumber, EMPLOYEE_ID_LOOKUP_DEBOUNCE_MS);
+    const debouncedWorkEmail = useDebounce(values.workEmail);
+    const debouncedEmployeeNumber = useDebounce(values.employeeNumber);
 
     const {
       data: checkEmailAndIdentificationNo,

--- a/frontend/src/community/people/constants/stringConstants.ts
+++ b/frontend/src/community/people/constants/stringConstants.ts
@@ -4,3 +4,5 @@ export enum characterLengths {
 }
 
 export const EMAIL_MAX_LENGTH = 100;
+
+export const EMPLOYEE_ID_LOOKUP_DEBOUNCE_MS = 500;

--- a/frontend/src/community/people/constants/stringConstants.ts
+++ b/frontend/src/community/people/constants/stringConstants.ts
@@ -5,4 +5,3 @@ export enum characterLengths {
 
 export const EMAIL_MAX_LENGTH = 100;
 
-export const EMPLOYEE_ID_LOOKUP_DEBOUNCE_MS = 500;

--- a/frontend/src/community/people/constants/stringConstants.ts
+++ b/frontend/src/community/people/constants/stringConstants.ts
@@ -4,4 +4,3 @@ export enum characterLengths {
 }
 
 export const EMAIL_MAX_LENGTH = 100;
-

--- a/frontend/src/community/people/hooks/useEmployeeDetailsFormHandler.tsx
+++ b/frontend/src/community/people/hooks/useEmployeeDetailsFormHandler.tsx
@@ -11,7 +11,9 @@ import React, {
 } from "react";
 
 import { useGetAllWorkLocations } from "~community/common/api/WorkLocationApi";
+import useDebounce from "~community/common/hooks/useDebounce";
 import useSessionData from "~community/common/hooks/useSessionData";
+import { EMPLOYEE_ID_LOOKUP_DEBOUNCE_MS } from "~community/people/constants/stringConstants";
 import { allowsAlphaNumericWithHyphenAndUnderscore } from "~community/common/regex/regexPatterns";
 import { DropdownListType } from "~community/common/types/CommonTypes";
 import { filterByValue } from "~community/common/utils/commonUtil";
@@ -113,13 +115,16 @@ const useEmployeeDetailsFormHandler = ({
     }
   );
 
+  const debouncedEmail = useDebounce(values.email as string, EMPLOYEE_ID_LOOKUP_DEBOUNCE_MS);
+  const debouncedEmployeeNumber = useDebounce(values.employeeNumber ?? "", EMPLOYEE_ID_LOOKUP_DEBOUNCE_MS);
+
   const {
     data: checkEmailAndIdentificationNo,
     refetch,
     isSuccess
   } = useCheckEmailAndIdentificationNo(
-    values.email as string,
-    values.employeeNumber ?? ""
+    debouncedEmail,
+    debouncedEmployeeNumber
   );
 
   useEffect(() => {
@@ -440,7 +445,7 @@ const useEmployeeDetailsFormHandler = ({
     if (!isManager && !isProfileView) {
       void refetch();
     }
-  }, [values.email, values.employeeNumber]);
+  }, [debouncedEmail, debouncedEmployeeNumber]);
 
   useEffect(() => {
     if (values.joinedDate) {

--- a/frontend/src/community/people/hooks/useEmployeeDetailsFormHandler.tsx
+++ b/frontend/src/community/people/hooks/useEmployeeDetailsFormHandler.tsx
@@ -13,7 +13,6 @@ import React, {
 import { useGetAllWorkLocations } from "~community/common/api/WorkLocationApi";
 import useDebounce from "~community/common/hooks/useDebounce";
 import useSessionData from "~community/common/hooks/useSessionData";
-import { EMPLOYEE_ID_LOOKUP_DEBOUNCE_MS } from "~community/people/constants/stringConstants";
 import { allowsAlphaNumericWithHyphenAndUnderscore } from "~community/common/regex/regexPatterns";
 import { DropdownListType } from "~community/common/types/CommonTypes";
 import { filterByValue } from "~community/common/utils/commonUtil";
@@ -115,8 +114,8 @@ const useEmployeeDetailsFormHandler = ({
     }
   );
 
-  const debouncedEmail = useDebounce(values.email as string, EMPLOYEE_ID_LOOKUP_DEBOUNCE_MS);
-  const debouncedEmployeeNumber = useDebounce(values.employeeNumber ?? "", EMPLOYEE_ID_LOOKUP_DEBOUNCE_MS);
+  const debouncedEmail = useDebounce(values.email as string);
+  const debouncedEmployeeNumber = useDebounce(values.employeeNumber ?? "");
 
   const {
     data: checkEmailAndIdentificationNo,


### PR DESCRIPTION
- Apply useDebounce(500ms) to workEmail and employeeNumber in EmploymentDetailsSection
- Apply useDebounce(500ms) to email and employeeNumber in useEmployeeDetailsFormHandler
- Pass debounced values to useCheckEmailAndIdentificationNo hook
- Use debounced values as useEffect dependencies to throttle refetch calls
- Reduces per-keystroke backend requests to 1 request per typing pause

Addresses: CWE-770, CWE-799, OWASP API4:2023 Unrestricted Resource Consumption

## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/[id]) 

### Summary

-

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
