### PR TITLE
fix: added isFetching to the loading flag

### DIFF
--- a/frontend/src/community/crm/api/CompanyApi.ts
+++ b/frontend/src/community/crm/api/CompanyApi.ts
@@ -49,7 +49,8 @@ export const useGetCompanyMetrics = (searchKeyword: string, limit: number) => {
     getNextPageParam: (lastPage) => {
       if (lastPage.currentPage + 1 >= lastPage.totalPages) return undefined;
       return lastPage.currentPage + 1;
-    }
+    },
+    refetchOnWindowFocus: false
   });
 };
 

--- a/frontend/src/community/crm/components/organisms/CompanyTable/CompanyTable.tsx
+++ b/frontend/src/community/crm/components/organisms/CompanyTable/CompanyTable.tsx
@@ -36,8 +36,14 @@ export const CompanyTable: FC = () => {
       ? EmptyStateTypeEnum.NO_DATA
       : EmptyStateTypeEnum.NO_SEARCH_RESULTS;
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
-    useGetCompanyMetrics(debouncedSearch, DEFAULT_PAGE_SIZE);
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    isFetching
+  } = useGetCompanyMetrics(debouncedSearch, DEFAULT_PAGE_SIZE);
 
   const { setSelectedCompany, setIsCrmSidePanelOpen } = useCrmStore(
     (store) => ({
@@ -170,7 +176,7 @@ export const CompanyTable: FC = () => {
         columns={columns as TableColumn<any>[]}
         data={companies ?? []}
         emptyStateType={emptyStateType}
-        isLoading={isLoading && companies?.length === 0}
+        isLoading={isLoading || isFetching}
         customSkeletonLoader={<ProjectTableSkeletonLoader rowCount={8} />}
         height="34.5rem"
         hasMore={hasNextPage}

--- a/frontend/src/community/crm/components/organisms/CompanyTable/CompanyTable.tsx
+++ b/frontend/src/community/crm/components/organisms/CompanyTable/CompanyTable.tsx
@@ -176,7 +176,10 @@ export const CompanyTable: FC = () => {
         columns={columns as TableColumn<any>[]}
         data={companies ?? []}
         emptyStateType={emptyStateType}
-        isLoading={isLoading || (isFetching && !isFetchingNextPage)}
+        isLoading={
+          (isLoading || (isFetching && !isFetchingNextPage)) &&
+          (companies?.length ?? 0) === 0
+        }
         customSkeletonLoader={<ProjectTableSkeletonLoader rowCount={8} />}
         height="34.5rem"
         hasMore={hasNextPage}

--- a/frontend/src/community/crm/components/organisms/CompanyTable/CompanyTable.tsx
+++ b/frontend/src/community/crm/components/organisms/CompanyTable/CompanyTable.tsx
@@ -176,7 +176,7 @@ export const CompanyTable: FC = () => {
         columns={columns as TableColumn<any>[]}
         data={companies ?? []}
         emptyStateType={emptyStateType}
-        isLoading={isLoading || isFetching}
+        isLoading={isLoading || (isFetching && !isFetchingNextPage)}
         customSkeletonLoader={<ProjectTableSkeletonLoader rowCount={8} />}
         height="34.5rem"
         hasMore={hasNextPage}

--- a/frontend/src/community/crm/components/organisms/CompanyTable/CompanyTable.tsx
+++ b/frontend/src/community/crm/components/organisms/CompanyTable/CompanyTable.tsx
@@ -41,7 +41,6 @@ export const CompanyTable: FC = () => {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-    isLoading,
     isFetching
   } = useGetCompanyMetrics(debouncedSearch, DEFAULT_PAGE_SIZE);
 

--- a/frontend/src/community/crm/components/organisms/CompanyTable/CompanyTable.tsx
+++ b/frontend/src/community/crm/components/organisms/CompanyTable/CompanyTable.tsx
@@ -177,8 +177,7 @@ export const CompanyTable: FC = () => {
         data={companies ?? []}
         emptyStateType={emptyStateType}
         isLoading={
-          (isLoading || (isFetching && !isFetchingNextPage)) &&
-          (companies?.length ?? 0) === 0
+          isFetching && !isFetchingNextPage && (companies?.length ?? 0) === 0
         }
         customSkeletonLoader={<ProjectTableSkeletonLoader rowCount={8} />}
         height="34.5rem"


### PR DESCRIPTION
## PR checklist

### TaskId: https://rootcode.skapp.com/pm/projects/CRM/items/338

### Summary

- Fixes CRM-338 Search Companies - Before fetching the items, the empty search results UI is displayed for a second

### How to test

1.

### Project Checklist

- [x] Changes build without any errors
- [ ] Have written adequate test cases
- [x] Done developer testing in
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
- [x] Code is formatted with `npm run format`
- [x] Code is linted with `npm run check-lint`
- [x] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [x] Pull request is raised from the correct source branch
- [x] Pull request is raised to the correct destination branch
- [x] Pull request is raised with correct title
- [x] Pull request is self reviewed
- [x] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
