### PR TITLE
fix: address book not updated when terminated user is reactivated

### DIFF
--- a/backend/src/main/java/com/skapp/community/common/util/event/UserReactivatedEvent.java
+++ b/backend/src/main/java/com/skapp/community/common/util/event/UserReactivatedEvent.java
@@ -1,0 +1,11 @@
+package com.skapp.community.common.util.event;
+
+import com.skapp.community.common.model.User;
+
+public class UserReactivatedEvent extends UserEvent {
+
+	public UserReactivatedEvent(Object source, User user) {
+		super(source, user);
+	}
+
+}

--- a/backend/src/main/java/com/skapp/community/peopleplanner/service/impl/PeopleServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/peopleplanner/service/impl/PeopleServiceImpl.java
@@ -28,6 +28,7 @@ import com.skapp.community.common.util.MessageUtil;
 import com.skapp.community.common.util.Validation;
 import com.skapp.community.common.util.event.UserCreatedEvent;
 import com.skapp.community.common.util.event.UserDeactivatedEvent;
+import com.skapp.community.common.util.event.UserReactivatedEvent;
 import com.skapp.community.common.util.transformer.PageTransformer;
 import com.skapp.community.leaveplanner.type.ManagerType;
 import com.skapp.community.peopleplanner.constant.PeopleConstants;
@@ -2554,11 +2555,12 @@ public class PeopleServiceImpl implements PeopleService {
 			employee.setTerminationDate(null);
 			user.setIsActive(true);
 
+			userDao.save(user);
+			applicationEventPublisher.publishEvent(new UserReactivatedEvent(this, user));
 			updateSubscriptionQuantity(1L, true, false);
 			userVersionService.upgradeUserVersion(user.getUserId(), VersionType.MAJOR);
 			invalidateUserCache();
 			invalidateUserAuthPicCache();
-			userDao.save(user);
 			log.info("updateUserStatus: execution ended - user activated");
 			return;
 		}


### PR DESCRIPTION
## Summary
- Reactivating a terminated employee left their AddressBook entry with isActive = false permanently
- Root cause: the reactivation path in updateUserStatus() returned early without publishing any event, while termination correctly published UserDeactivatedEvent and triggered the address book deactivation listener
- Fix: introduce UserReactivatedEvent, publish it in the reactivation path, and add a listener that sets addressBook.isActive = true — symmetric with the deactivation flow

## Changes
- New: UserReactivatedEvent extending UserEvent (mirrors UserDeactivatedEvent)
- PeopleServiceImpl: publish UserReactivatedEvent after saving the reactivated user in updateUserStatus()
- Enterprise submodule (skapp-ep-be-src PR #686): add handleUserReactivation listener in UserDeactivatedEventHandler

## Test plan
- [ ] Terminate an employee and verify their address book entry becomes inactive
- [ ] Reactivate the same employee and verify their address book entry becomes active again
- [ ] Confirm no regression on fresh user creation: address book entry is created and active

Generated with Claude Code