### PR TITLE
Fix/allowing member transfer to existing teams when deleting teams

### DIFF
--- a/frontend/src/community/common/assets/languages/english/peopleModule.json
+++ b/frontend/src/community/common/assets/languages/english/peopleModule.json
@@ -36,6 +36,7 @@
     "teamNameDuplicateError": "Team name already exists.",
     "confirmDeleteModalTitle": "Confirm deletion",
     "confirmDeleteModalDes": "Proceeding with this deletion will remove all members from the team. Would you like to reassign the members first or continue with deleting the team?",
+    "confirmDeleteModalDesNoReassign": "Proceeding with this deletion will remove all members from the team.",
     "teamDeleteConfirmBtnText": "Proceed to delete",
     "reassignBtnText": "Reassign members",
     "reassignModalTitle": "Reassign team members",

--- a/frontend/src/community/people/components/molecules/ReassignMemberRow/ReassignMemberRow.tsx
+++ b/frontend/src/community/people/components/molecules/ReassignMemberRow/ReassignMemberRow.tsx
@@ -11,37 +11,32 @@ import AvatarChip from "~community/common/components/molecules/AvatarChip/Avatar
 import RoundedSelect from "~community/common/components/molecules/RoundedSelect/RoundedSelect";
 import { ZIndexEnums } from "~community/common/enums/CommonEnums";
 import { useTranslator } from "~community/common/hooks/useTranslator";
-import { useGetAllTeams } from "~community/people/api/TeamApi";
-import { usePeopleStore } from "~community/people/store/store";
 import { EmployeeType } from "~community/people/types/EmployeeTypes";
-import { TeamNamesType } from "~community/people/types/TeamTypes";
+import { TeamNamesType, TeamType } from "~community/people/types/TeamTypes";
 
 import styles from "./styles";
 
 interface Props {
   teamMember: EmployeeType;
+  availableTeams: TeamType[];
   setTeamId?: (teamId: number) => void;
 }
 
-const ReassignMemberRow = ({ teamMember, setTeamId }: Props) => {
+const ReassignMemberRow = ({
+  teamMember,
+  availableTeams,
+  setTeamId
+}: Props) => {
   const theme: Theme = useTheme();
 
   const classes = styles();
 
   const translateText = useTranslator("peopleModule", "teams");
 
-  const { currentDeletingTeam } = usePeopleStore((state) => state);
-
   const [selectedTeam, setSelectedTeam] = useState<TeamNamesType | undefined>();
 
-  const { data: allTeams } = useGetAllTeams();
-
-  const filteredTeams = allTeams?.filter(
-    (team) => team?.teamId !== currentDeletingTeam?.teamId
-  );
-
   const teamOptions =
-    filteredTeams?.map((team) => ({
+    availableTeams?.map((team) => ({
       label: team?.teamName,
       value: team.teamId,
       disabled: false,
@@ -51,7 +46,7 @@ const ReassignMemberRow = ({ teamMember, setTeamId }: Props) => {
   const handleTeamSelectChange = (event: SelectChangeEvent) => {
     const selectedTeamId = event.target.value;
 
-    const team = filteredTeams?.find(
+    const team = availableTeams?.find(
       (team) => team.teamId.toString() === selectedTeamId.toString()
     );
 
@@ -107,7 +102,7 @@ const ReassignMemberRow = ({ teamMember, setTeamId }: Props) => {
           label: `${teamMember?.firstName} ${teamMember?.lastName}`
         }}
         renderValue={(selectedValue) => {
-          const team = filteredTeams?.find(
+          const team = availableTeams?.find(
             (team) => team.teamId.toString() === selectedValue.toString()
           );
 

--- a/frontend/src/community/people/components/molecules/TeamModals/DeleteConfirmModal/DeleteConfirmModal.tsx
+++ b/frontend/src/community/people/components/molecules/TeamModals/DeleteConfirmModal/DeleteConfirmModal.tsx
@@ -32,6 +32,7 @@ const DeleteConfirmModal = ({ hasTransferableMembers }: Props) => {
       description: translateText(["teamDeleteSuccessDes"]),
       isIcon: true
     });
+    setCurrentDeletingTeam(undefined);
   };
 
   const handleError = () => {
@@ -50,19 +51,20 @@ const DeleteConfirmModal = ({ hasTransferableMembers }: Props) => {
     setTeamModalType(TeamModelTypes.REASSIGN_MEMBERS);
   };
 
-  const handleDeleteClick = async () => {
+  const handleDeleteClick = () => {
+    if (!currentDeletingTeam) return;
+
     setIsTeamModalOpen(false);
     setTeamModalType(TeamModelTypes.CONFIRM_DELETE);
 
     const transferMembers: never[] = [];
 
     const data = {
-      teamId: currentDeletingTeam!.teamId.toString(),
+      teamId: currentDeletingTeam.teamId.toString(),
       transferMembers
     };
 
-    await mutate(data);
-    setCurrentDeletingTeam(undefined);
+    mutate(data);
   };
   return (
     <Box>

--- a/frontend/src/community/people/components/molecules/TeamModals/DeleteConfirmModal/DeleteConfirmModal.tsx
+++ b/frontend/src/community/people/components/molecules/TeamModals/DeleteConfirmModal/DeleteConfirmModal.tsx
@@ -9,7 +9,11 @@ import { useTransferTeamMembers } from "~community/people/api/TeamApi";
 import { usePeopleStore } from "~community/people/store/store";
 import { TeamModelTypes } from "~community/people/types/TeamTypes";
 
-const DeleteConfirmModal = () => {
+interface Props {
+  hasTransferableMembers: boolean;
+}
+
+const DeleteConfirmModal = ({ hasTransferableMembers }: Props) => {
   const translateText = useTranslator("peopleModule", "teams");
   const {
     setTeamModalType,
@@ -65,14 +69,16 @@ const DeleteConfirmModal = () => {
       <Typography>{translateText(["confirmDeleteModalDes"])}</Typography>
       <Box>
         <div className="flex flex-row gap-3 mt-4 justify-end">
-          <ButtonV2
-            variant={"primary"}
-            onClick={handleReassignClick}
-            icon={<Icon name={IconName.RIGHT_ARROW_ICON} />}
-            iconPosition="end"
-          >
-            {translateText(["reassignBtnText"])}
-          </ButtonV2>
+          {hasTransferableMembers && (
+            <ButtonV2
+              variant={"primary"}
+              onClick={handleReassignClick}
+              icon={<Icon name={IconName.RIGHT_ARROW_ICON} />}
+              iconPosition="end"
+            >
+              {translateText(["reassignBtnText"])}
+            </ButtonV2>
+          )}
           <ButtonV2
             variant={"error"}
             onClick={handleDeleteClick}

--- a/frontend/src/community/people/components/molecules/TeamModals/DeleteConfirmModal/DeleteConfirmModal.tsx
+++ b/frontend/src/community/people/components/molecules/TeamModals/DeleteConfirmModal/DeleteConfirmModal.tsx
@@ -57,7 +57,7 @@ const DeleteConfirmModal = ({ hasTransferableMembers }: Props) => {
     const transferMembers: never[] = [];
 
     const data = {
-      teamId: currentDeletingTeam?.teamId.toString(),
+      teamId: currentDeletingTeam!.teamId.toString(),
       transferMembers
     };
 
@@ -66,7 +66,13 @@ const DeleteConfirmModal = ({ hasTransferableMembers }: Props) => {
   };
   return (
     <Box>
-      <Typography>{translateText(["confirmDeleteModalDes"])}</Typography>
+      <Typography>
+        {translateText([
+          hasTransferableMembers
+            ? "confirmDeleteModalDes"
+            : "confirmDeleteModalDesNoReassign"
+        ])}
+      </Typography>
       <Box>
         <div className="flex flex-row gap-3 mt-4 justify-end">
           {hasTransferableMembers && (

--- a/frontend/src/community/people/components/molecules/TeamModals/ReassignMembersModal/ReassignMembersModal.tsx
+++ b/frontend/src/community/people/components/molecules/TeamModals/ReassignMembersModal/ReassignMembersModal.tsx
@@ -8,9 +8,18 @@ import { IconName } from "~community/common/types/IconTypes";
 import { useTransferTeamMembers } from "~community/people/api/TeamApi";
 import ReassignMemberRow from "~community/people/components/molecules/ReassignMemberRow/ReassignMemberRow";
 import { usePeopleStore } from "~community/people/store/store";
-import { TeamModelTypes } from "~community/people/types/TeamTypes";
+import { EmployeeType } from "~community/people/types/EmployeeTypes";
+import { TeamModelTypes, TeamType } from "~community/people/types/TeamTypes";
 
-const ReassignMembersModal = () => {
+interface Props {
+  transferableMembers: EmployeeType[];
+  availableTeamsMap: Map<number, TeamType[]>;
+}
+
+const ReassignMembersModal = ({
+  transferableMembers,
+  availableTeamsMap
+}: Props) => {
   const translateText = useTranslator("peopleModule", "teams");
   const {
     currentDeletingTeam,
@@ -34,16 +43,13 @@ const ReassignMembersModal = () => {
   };
 
   const reassignAndDeleteClick = async () => {
-    const transferMembers = [
-      ...(currentDeletingTeam?.supervisors || []),
-      ...(currentDeletingTeam?.teamMembers || [])
-    ].map((member) => ({
+    const transferMembers = transferableMembers.map((member) => ({
       employeeId: +member.employeeId,
-      teamId: memberTeamAssignments[+member.employeeId] || null
+      teamId: memberTeamAssignments[+member.employeeId] ?? null
     }));
 
     const data = {
-      teamId: currentDeletingTeam?.teamId,
+      teamId: currentDeletingTeam!.teamId.toString(),
       transferMembers
     };
 
@@ -79,22 +85,14 @@ const ReassignMembersModal = () => {
     <div>
       <p className="my-4">{translateText(["reassignModalDes"])}</p>
       <div className="flex flex-col gap-2 max-h-56 overflow-auto">
-        {currentDeletingTeam?.supervisors?.map((supervisor) => (
+        {transferableMembers.map((member) => (
           <ReassignMemberRow
-            key={supervisor.employeeId}
-            teamMember={supervisor}
-            setTeamId={(teamId) =>
-              setTeamId(Number(supervisor.employeeId), teamId)
+            key={member.employeeId}
+            teamMember={member}
+            availableTeams={
+              availableTeamsMap.get(Number(member.employeeId)) || []
             }
-          />
-        ))}
-        {currentDeletingTeam?.teamMembers?.map((teamMember) => (
-          <ReassignMemberRow
-            key={teamMember.employeeId}
-            teamMember={teamMember}
-            setTeamId={(teamId) =>
-              setTeamId(Number(teamMember.employeeId), teamId)
-            }
+            setTeamId={(teamId) => setTeamId(Number(member.employeeId), teamId)}
           />
         ))}
       </div>

--- a/frontend/src/community/people/components/molecules/TeamModals/ReassignMembersModal/ReassignMembersModal.tsx
+++ b/frontend/src/community/people/components/molecules/TeamModals/ReassignMembersModal/ReassignMembersModal.tsx
@@ -28,7 +28,7 @@ const ReassignMembersModal = ({
     setCurrentDeletingTeam
   } = usePeopleStore((state) => state);
 
-  const { mutate } = useTransferTeamMembers();
+  const { mutateAsync } = useTransferTeamMembers();
   const { setToastMessage } = useToast();
 
   const [memberTeamAssignments, setMemberTeamAssignments] = useState<
@@ -43,18 +43,22 @@ const ReassignMembersModal = ({
   };
 
   const reassignAndDeleteClick = async () => {
-    const transferMembers = transferableMembers.map((member) => ({
-      employeeId: +member.employeeId,
-      teamId: memberTeamAssignments[+member.employeeId] ?? null
-    }));
+    if (!currentDeletingTeam) return;
+
+    const transferMembers = transferableMembers
+      .filter((member) => memberTeamAssignments[Number(member.employeeId)] !== undefined)
+      .map((member) => ({
+        employeeId: Number(member.employeeId),
+        teamId: memberTeamAssignments[Number(member.employeeId)]
+      }));
 
     const data = {
-      teamId: currentDeletingTeam!.teamId.toString(),
+      teamId: currentDeletingTeam.teamId.toString(),
       transferMembers
     };
 
     try {
-      await mutate(data);
+      await mutateAsync(data);
       setToastMessage({
         open: true,
         toastType: "success",
@@ -64,7 +68,7 @@ const ReassignMembersModal = ({
       });
       setIsTeamModalOpen(false);
       setCurrentDeletingTeam(undefined);
-    } catch (error) {
+    } catch {
       setToastMessage({
         open: true,
         toastType: "error",

--- a/frontend/src/community/people/components/organisms/TeamModalController/TeamModalController.tsx
+++ b/frontend/src/community/people/components/organisms/TeamModalController/TeamModalController.tsx
@@ -1,6 +1,14 @@
-import { Dispatch, FC, ReactNode, SetStateAction, useEffect, useState } from "react";
-
 import { SmallModal } from "@rootcodelabs/skapp-ui";
+import {
+  Dispatch,
+  FC,
+  ReactNode,
+  SetStateAction,
+  useEffect,
+  useMemo,
+  useState
+} from "react";
+
 import useSessionData from "~community/common/hooks/useSessionData";
 import { useTranslator } from "~community/common/hooks/useTranslator";
 import { useGetAllTeams } from "~community/people/api/TeamApi";
@@ -11,10 +19,12 @@ import TeamActionModal from "~community/people/components/molecules/TeamModals/T
 import UnsavedAddTeamModal from "~community/people/components/molecules/TeamModals/UnsavedAddTeamModal/UnsavedAddTeamModal";
 import UnsavedEditTeamModal from "~community/people/components/molecules/TeamModals/UnsavedEditTeamModal/UnsavedEditTeamModal";
 import { usePeopleStore } from "~community/people/store/store";
+import { EmployeeType } from "~community/people/types/EmployeeTypes";
 import {
   AddTeamType,
   TeamModelTypes,
-  TeamNamesType
+  TeamNamesType,
+  TeamType
 } from "~community/people/types/TeamTypes";
 import { useCommonEnterpriseStore } from "~enterprise/common/store/commonStore";
 
@@ -53,8 +63,64 @@ const TeamModalController: FC<Props> = ({ setLatestTeamId }) => {
   const [tempTeamDetails, setTempTeamDetails] = useState<AddTeamType>();
   const [currentTeamFormData, setCurrentTeamFormData] = useState<AddTeamType>();
 
-
   const { isLoading: teamsIsLoading, data } = useGetAllTeams();
+
+  const { hasTransferableMembers, transferableMembers, availableTeamsMap } =
+    useMemo(() => {
+      if (!data || !currentDeletingTeam) {
+        return {
+          hasTransferableMembers: false,
+          transferableMembers: [] as EmployeeType[],
+          availableTeamsMap: new Map<number, TeamType[]>()
+        };
+      }
+
+      const otherTeams = data.filter(
+        (team) => team.teamId !== currentDeletingTeam.teamId
+      );
+
+      const memberTeamsMap = new Map<number, Set<string | number>>();
+      for (const team of otherTeams) {
+        const allEmployees = [
+          ...(team.supervisors || []),
+          ...(team.teamMembers || [])
+        ];
+        for (const emp of allEmployees) {
+          const employeeId = Number(emp.employeeId);
+          if (!memberTeamsMap.has(employeeId)) {
+            memberTeamsMap.set(employeeId, new Set());
+          }
+          memberTeamsMap.get(employeeId)!.add(team.teamId);
+        }
+      }
+
+      const deletingTeamMembers = [
+        ...(currentDeletingTeam.supervisors || []),
+        ...(currentDeletingTeam.teamMembers || [])
+      ];
+
+      const transferable: EmployeeType[] = [];
+      const teamsMap = new Map<number, TeamType[]>();
+
+      for (const member of deletingTeamMembers) {
+        const employeeId = Number(member.employeeId);
+        const existingTeamIds = memberTeamsMap.get(employeeId) || new Set();
+        const transferableTeams = otherTeams.filter(
+          (team) => !existingTeamIds.has(team.teamId)
+        );
+
+        if (transferableTeams.length > 0) {
+          transferable.push(member);
+          teamsMap.set(employeeId, transferableTeams);
+        }
+      }
+
+      return {
+        hasTransferableMembers: transferable.length > 0,
+        transferableMembers: transferable,
+        availableTeamsMap: teamsMap
+      };
+    }, [data, currentDeletingTeam]);
 
   const getModalTitle = (): string => {
     switch (teamModalType) {
@@ -136,8 +202,7 @@ const TeamModalController: FC<Props> = ({ setLatestTeamId }) => {
   };
 
   useEffect(() => {
-    if (!teamsIsLoading && data)
-      setProjectTeamNames(data as TeamNamesType[]);
+    if (!teamsIsLoading && data) setProjectTeamNames(data as TeamNamesType[]);
   }, [teamsIsLoading, data]);
 
   const modalContent = (): ReactNode => {
@@ -162,11 +227,7 @@ const TeamModalController: FC<Props> = ({ setLatestTeamId }) => {
           />
         );
       case TeamModelTypes.UNSAVED_ADD_TEAM:
-        return (
-          <UnsavedAddTeamModal
-            setTempTeamDetails={setTempTeamDetails}
-          />
-        );
+        return <UnsavedAddTeamModal setTempTeamDetails={setTempTeamDetails} />;
       case TeamModelTypes.UNSAVED_EDIT_TEAM:
         return (
           <UnsavedEditTeamModal
@@ -175,9 +236,16 @@ const TeamModalController: FC<Props> = ({ setLatestTeamId }) => {
           />
         );
       case TeamModelTypes.CONFIRM_DELETE:
-        return <DeleteConfirmModal />;
+        return (
+          <DeleteConfirmModal hasTransferableMembers={hasTransferableMembers} />
+        );
       case TeamModelTypes.REASSIGN_MEMBERS:
-        return <ReassignMembersModal />;
+        return (
+          <ReassignMembersModal
+            transferableMembers={transferableMembers}
+            availableTeamsMap={availableTeamsMap}
+          />
+        );
       default:
         return null;
     }
@@ -193,7 +261,9 @@ const TeamModalController: FC<Props> = ({ setLatestTeamId }) => {
         }
         onClose={handleCloseModal}
         modalHeader={
-          isPeopleAdmin ? getModalTitle() : translateText(["viewTeamModalTitle"])
+          isPeopleAdmin
+            ? getModalTitle()
+            : translateText(["viewTeamModalTitle"])
         }
         content={modalContent()}
       />

--- a/frontend/src/community/people/components/organisms/TeamModalController/TeamModalController.tsx
+++ b/frontend/src/community/people/components/organisms/TeamModalController/TeamModalController.tsx
@@ -76,7 +76,8 @@ const TeamModalController: FC<Props> = ({ setLatestTeamId }) => {
       }
 
       const otherTeams = data.filter(
-        (team) => team.teamId !== currentDeletingTeam.teamId
+        (team) =>
+          team.teamId.toString() !== currentDeletingTeam.teamId.toString()
       );
 
       const memberTeamsMap = new Map<number, Set<string | number>>();


### PR DESCRIPTION
This pull request refactors the team deletion and member reassignment modals in the community people module to improve clarity, maintainability, and user experience. The main changes include centralizing the logic for determining transferable members and available teams, passing this data explicitly to modal components, and updating modal messaging and UI to better reflect available actions.

**Refactoring modal logic and data flow:**

- Centralized the logic for determining which team members can be reassigned and which teams are available for reassignment into a `useMemo` block in `TeamModalController.tsx`. This information is now passed as props to the relevant modal components, ensuring consistent and accurate data handling.

- Updated `ReassignMembersModal` and `ReassignMemberRow` components to accept `transferableMembers` and `availableTeamsMap` as props, removing their internal dependency on global store and API calls. This makes the components more modular and easier to test. [[1]](diffhunk://#diff-67d56cfb505a5936c37e35eba0b3f733d6ca9fe4e56608a41947b8db830920b0L11-R22) [[2]](diffhunk://#diff-67d56cfb505a5936c37e35eba0b3f733d6ca9fe4e56608a41947b8db830920b0L82-R95) [[3]](diffhunk://#diff-90c07b735c457d9a2b76b4268c442b6bfe4bc8c0c695e067e2276a066cdecb86L14-R39) [[4]](diffhunk://#diff-90c07b735c457d9a2b76b4268c442b6bfe4bc8c0c695e067e2276a066cdecb86L54-R49) [[5]](diffhunk://#diff-90c07b735c457d9a2b76b4268c442b6bfe4bc8c0c695e067e2276a066cdecb86L110-R105)

**User experience improvements:**

- Modified the `DeleteConfirmModal` to dynamically display the appropriate confirmation message and action buttons depending on whether there are transferable members, using the new `hasTransferableMembers` prop. [[1]](diffhunk://#diff-5021157517b666f966a45320e742f4b23c2358a4cfe51abbbcde7781203cf977L12-R16) [[2]](diffhunk://#diff-5021157517b666f966a45320e742f4b23c2358a4cfe51abbbcde7781203cf977L65-R78) [[3]](diffhunk://#diff-5021157517b666f966a45320e742f4b23c2358a4cfe51abbbcde7781203cf977R87)

- Added a new translation key `confirmDeleteModalDesNoReassign` for the scenario where no members can be reassigned before team deletion.

**Data consistency and type safety:**

- Ensured that team IDs are consistently converted to strings when calling the API for deleting or reassigning team members, and improved null/undefined handling. [[1]](diffhunk://#diff-67d56cfb505a5936c37e35eba0b3f733d6ca9fe4e56608a41947b8db830920b0L37-R52) [[2]](diffhunk://#diff-5021157517b666f966a45320e742f4b23c2358a4cfe51abbbcde7781203cf977L56-R60)

**Minor code cleanup:**

- Improved import organization and removed unused imports for better readability. [[1]](diffhunk://#diff-bf2d1dab2e8e1accbb60392352835c164d7e06645825e77058bf03fcc82038a9L1-R11) [[2]](diffhunk://#diff-bf2d1dab2e8e1accbb60392352835c164d7e06645825e77058bf03fcc82038a9R22-R27)

These changes collectively make the team deletion and reassignment workflow more robust, modular, and user-friendly.## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/[id]) 

### Summary

-

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
