### PR TITLE
fix(people): fix subscription increment for deactivated guest user conversion

### DIFF
--- a/backend/src/main/java/com/skapp/community/peopleplanner/service/impl/PeopleServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/peopleplanner/service/impl/PeopleServiceImpl.java
@@ -214,10 +214,12 @@ public class PeopleServiceImpl implements PeopleService {
 		boolean isGuestConversion = false;
 
 		Optional<User> existingGuestUser = findGuestUserByEmail(requestDto);
+		boolean wasDeactivatedGuest = false;
 		if (existingGuestUser.isPresent()) {
 			user = existingGuestUser.get();
 			user.setIsActive(true);
 			employee = user.getEmployee();
+			wasDeactivatedGuest = employee.getAccountStatus() == AccountStatus.DEACTIVATED;
 			// Reset to PENDING so createUserEntity triggers credential setup and
 			// invitation email
 			employee.setAccountStatus(AccountStatus.PENDING);
@@ -243,6 +245,10 @@ public class PeopleServiceImpl implements PeopleService {
 			peopleEmailService.sendUserInvitationEmail(user, tempPassword);
 			updateSubscriptionQuantity(1L, true, false);
 		}
+		else if (wasDeactivatedGuest) {
+			updateSubscriptionQuantity(1L, true, false);
+		}
+
 		invalidateUserCache();
 		invalidateUserAuthPicCache();
 
@@ -262,10 +268,12 @@ public class PeopleServiceImpl implements PeopleService {
 		CreateEmployeeRequestDto createEmployeeRequestDto = createEmployeeRequest(employeeQuickAddDto);
 
 		Optional<User> existingGuestUser = findGuestUserByEmail(createEmployeeRequestDto);
+		boolean wasDeactivatedGuest = false;
 		if (existingGuestUser.isPresent()) {
 			user = existingGuestUser.get();
 			user.setIsActive(true);
 			employee = user.getEmployee();
+			wasDeactivatedGuest = employee.getAccountStatus() == AccountStatus.DEACTIVATED;
 			// Reset to PENDING so createUserEntity triggers credential setup and
 			// invitation email
 			employee.setAccountStatus(AccountStatus.PENDING);
@@ -286,6 +294,9 @@ public class PeopleServiceImpl implements PeopleService {
 			// Skip for guest conversion: email is sent via createUserEntity ->
 			// resendInvitationEmail
 			peopleEmailService.sendUserInvitationEmail(user, tempPassword);
+			updateSubscriptionQuantity(1L, true, false);
+		}
+		else if (wasDeactivatedGuest) {
 			updateSubscriptionQuantity(1L, true, false);
 		}
 		invalidateUserCache();


### PR DESCRIPTION


Captured wasDeactivatedGuest flag before mutating accountStatus to PENDING, so deactivated guest -> employee conversions correctly trigger subscription increment. Simplified redundant null/role checks already guaranteed by findGuestUserByEmail filter.

## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/[id]) 

### Summary

-

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
