### PR TITLE
Fix/2327: Main content loader content gets split when there a success/error/warning toast at some instances

### DIFF
--- a/frontend/src/community/common/components/molecules/FullScreenLoader/FullScreenLoader.tsx
+++ b/frontend/src/community/common/components/molecules/FullScreenLoader/FullScreenLoader.tsx
@@ -5,9 +5,10 @@ import { useTranslator } from "~community/common/hooks/useTranslator";
 
 interface Props {
   fullPage?: boolean;
+  zIndex?: number;
 }
 
-const FullScreenLoader = ({ fullPage = true }: Props) => {
+const FullScreenLoader = ({ fullPage = true, zIndex = ZIndexEnums.MAX }: Props) => {
   const theme = useTheme();
   const translateAria = useTranslator(
     "commonAria",
@@ -24,7 +25,7 @@ const FullScreenLoader = ({ fullPage = true }: Props) => {
         alignItems: "center",
         justifyContent: "center",
         backgroundColor: theme.palette.background.default,
-        zIndex: ZIndexEnums.MAX
+        zIndex: zIndex
       }}
       role="status"
       aria-live="polite"

--- a/frontend/src/community/common/components/organisms/ContentWithDrawer/ContentWithDrawer.tsx
+++ b/frontend/src/community/common/components/organisms/ContentWithDrawer/ContentWithDrawer.tsx
@@ -6,6 +6,7 @@ import FullScreenLoader from "~community/common/components/molecules/FullScreenL
 import ToastMessage from "~community/common/components/molecules/ToastMessage/ToastMessage";
 import AppBar from "~community/common/components/organisms/AppBar/AppBar";
 import Drawer from "~community/common/components/organisms/Drawer/Drawer";
+import { ZIndexEnums } from "~community/common/enums/CommonEnums";
 import useRouteLoading from "~community/common/hooks/useRouteLoading";
 import { useTranslator } from "~community/common/hooks/useTranslator";
 import {
@@ -46,7 +47,7 @@ const ContentWithDrawer = ({ children }: Props) => {
                 minHeight: "100dvh"
               }}
             >
-              <FullScreenLoader fullPage={false} />
+              <FullScreenLoader fullPage={false} zIndex={ZIndexEnums.MODAL} />
             </div>
           ) : (
             <main


### PR DESCRIPTION
…ror/warning toast at some instances

## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/[id]) 

### Summary

-

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
