### PR TITLE
Fix/2380 people bulk upload next button blink

### DIFF
--- a/frontend/src/community/people/components/molecules/UserBulkUploadModals/UserBulkCsvUpload.tsx
+++ b/frontend/src/community/people/components/molecules/UserBulkUploadModals/UserBulkCsvUpload.tsx
@@ -183,7 +183,9 @@ const UserBulkCsvUpload: FC<Props> = ({
           isLoading={isPending}
           disabled={bulkUserAttachment?.length === 0}
           aria-label={translateAria(["uploadPeople"])}
-          className={getBlinkClass(bulkUserAttachment?.length > 0)}
+          className={getBlinkClass(
+            ongoingQuickSetup.INVITE_EMPLOYEES && bulkUserAttachment?.length > 0
+          )}
           icon={<ArrowRightIcon />}
           iconPosition="end"
         >


### PR DESCRIPTION
## Description
Fixes #2380 — the Next/Upload button in the People bulk CSV upload modal was blinking outside of the invite-employees quick setup flow.

## Change
Gate the blink class on `ongoingQuickSetup.INVITE_EMPLOYEES` in addition to having files attached, so the button only blinks during the INVITE_EMPLOYEES quick setup step.

## File
- `frontend/src/community/people/components/molecules/UserBulkUploadModals/UserBulkCsvUpload.tsx`