### PR TITLE
fix: notify supervisor on employee leave request cancellation

### DIFF
--- a/backend/src/main/java/com/skapp/community/leaveplanner/service/impl/LeaveServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/service/impl/LeaveServiceImpl.java
@@ -340,22 +340,8 @@ public class LeaveServiceImpl implements LeaveService {
 
 		leaveRequest = leaveRequestDao.save(leaveRequest);
 
-		boolean isSingleDay = leaveRequest.getStartDate().equals(leaveRequest.getEndDate());
-		List<EmployeeManager> employeeManagers = employeeManagerDao.findByEmployee(currentUser.getEmployee());
-
 		if (leavePatchRequestDto.getLeaveRequestStatus().equals(LeaveRequestStatus.CANCELLED)) {
-			leaveEmailService.sendCancelLeaveRequestEmployeeEmail(currentUser.getEmail(),
-					currentUser.getEmployee().getFirstName(), currentUser.getEmployee().getLastName(),
-					leaveRequest.getLeaveState().toString(), leaveRequest.getLeaveType().getName(),
-					leaveRequest.getStartDate(), leaveRequest.getEndDate(), isSingleDay);
-			leaveEmailService.sendCancelLeaveRequestManagerEmail(employeeManagers,
-					currentUser.getEmployee().getFirstName(), currentUser.getEmployee().getLastName(),
-					leaveRequest.getLeaveState().toString(), leaveRequest.getLeaveType().getName(),
-					leaveRequest.getStartDate(), leaveRequest.getEndDate(), isSingleDay);
-			leaveNotificationService.sendCancelLeaveRequestEmployeeNotification(currentUser.getEmployee(),
-					employeeManagers, leaveRequest, isSingleDay);
-			leaveNotificationService.sendCancelLeaveRequestManagerNotification(currentUser.getEmployee(),
-					employeeManagers, leaveRequest, isSingleDay);
+			sendCancelLeaveRequestEmailsAndNotifications(currentUser, leaveRequest);
 		}
 
 		LeaveRequestByIdResponseDto leaveRequestResponseDto = leaveMapper
@@ -442,11 +428,31 @@ public class LeaveServiceImpl implements LeaveService {
 
 		leaveRequest = leaveRequestDao.save(leaveRequest);
 
+		sendCancelLeaveRequestEmailsAndNotifications(currentUser, leaveRequest);
+
 		LeaveRequestResponseDto leaveRequestResDto = leaveMapper.leaveRequestToLeaveRequestResponseDto(leaveRequest);
 
 		log.info("deleteLeaveRequestById: execution ended successfully for Leave Request: {}",
 				leaveRequest.getLeaveRequestId());
 		return new ResponseEntityDto(false, leaveRequestResDto);
+	}
+
+	private void sendCancelLeaveRequestEmailsAndNotifications(User currentUser, LeaveRequest leaveRequest) {
+		boolean isSingleDay = leaveRequest.getStartDate().equals(leaveRequest.getEndDate());
+		List<EmployeeManager> employeeManagers = employeeManagerDao.findByEmployee(currentUser.getEmployee());
+
+		leaveEmailService.sendCancelLeaveRequestEmployeeEmail(currentUser.getEmail(),
+				currentUser.getEmployee().getFirstName(), currentUser.getEmployee().getLastName(),
+				leaveRequest.getLeaveState().toString(), leaveRequest.getLeaveType().getName(),
+				leaveRequest.getStartDate(), leaveRequest.getEndDate(), isSingleDay);
+		leaveEmailService.sendCancelLeaveRequestManagerEmail(employeeManagers, currentUser.getEmployee().getFirstName(),
+				currentUser.getEmployee().getLastName(), leaveRequest.getLeaveState().toString(),
+				leaveRequest.getLeaveType().getName(), leaveRequest.getStartDate(), leaveRequest.getEndDate(),
+				isSingleDay);
+		leaveNotificationService.sendCancelLeaveRequestEmployeeNotification(currentUser.getEmployee(), employeeManagers,
+				leaveRequest, isSingleDay);
+		leaveNotificationService.sendCancelLeaveRequestManagerNotification(currentUser.getEmployee(), employeeManagers,
+				leaveRequest, isSingleDay);
 	}
 
 	@Override


### PR DESCRIPTION
## Summary

Supervisors were not receiving any notification or email when an employee cancelled a leave request.

**Root cause:** The UI cancel action calls `DELETE /leaves/{id}` → `LeaveServiceImpl.deleteLeaveRequestById`, which only set the status to `CANCELLED` and deducted entitlement hours — it never sent any email or in-app notification. The cancellation notification logic existed **only** in the separate PATCH path (`updateLeaveRequestByEmployee`), which the cancel action does not use.

## Fix

- Extracted the four cancel email/notification calls into a shared private helper `sendCancelLeaveRequestEmailsAndNotifications(currentUser, leaveRequest)`.
- Invoke it from `deleteLeaveRequestById` (the actual UI cancel path) — **this is the fix**.
- Refactored the existing PATCH path (`updateLeaveRequestByEmployee`) to call the same helper (no behavior change there), so both cancel paths stay in sync.

The helper sends, on cancellation:
- Employee confirmation email + in-app notification
- Supervisor(s) email + in-app notification

Recipients resolve via `employeeManagerDao.findByEmployee(...)` (primary + secondary supervisors), filtered by `PeopleUtil.filterManagersByLeaveRoles(...)` (Leave Manager / Leave Admin) — consistent with the apply/approve flows.

## Bug report

- **Env:** Enterprise - Core - DEV
- **Severity:** Major
- **Steps:** Submit a leave request as employee → cancel it → check supervisor's notifications and email inbox.
- **Before:** Supervisor received nothing.
- **After:** Supervisor receives both an in-app notification and an email.

## Testing

- Backend compiles cleanly (`mvn compile`), spring-javaformat validation passes.
- Manual end-to-end verification on DEV recommended: cancel a leave request as an employee and confirm the assigned supervisor (with a Leave Manager/Admin role) receives both the notification and the email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)