### PR TITLE
fix: show country for restricted profile viewers

### DIFF
--- a/backend/src/main/java/com/skapp/community/peopleplanner/service/impl/PeopleReadServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/peopleplanner/service/impl/PeopleReadServiceImpl.java
@@ -121,6 +121,10 @@ public class PeopleReadServiceImpl implements PeopleReadService {
 		dto.setGeneral(mapPersonalGeneralDetails(employee, accessLevel));
 		dto.setSkills(mapEmployeeSkills(employee));
 
+		EmployeePersonalContactDetailsDto contactDto = new EmployeePersonalContactDetailsDto();
+		contactDto.setCountry(employee.getCountry());
+		dto.setContact(contactDto);
+
 		if (accessLevel.canSeeSensitiveData()) {
 			dto.setContact(mapPersonalContactDetails(employee));
 


### PR DESCRIPTION
## Summary

Fixes the bug where the **country value is not displayed** in a user's profile even though a country has been set (reported for the Super Admin user, but affects any user).

### Root cause
The country field is rendered inside the **always-visible general details section** of the profile (read-only view), but it reads its value from `personal.contact.country`. On the backend, `country` was only populated inside the **sensitive contact block**, which is gated behind `accessLevel.canSeeSensitiveData()`. So when a regular user views another user's profile (`RESTRICTED` access), the whole contact block is dropped and the country field renders with an empty value.

### Fix
In `PeopleReadServiceImpl.mapPersonalDetails`, always set `country` on the contact DTO for every viewer. Viewers with sensitive-data access still get the full contact block (email, phone, address); restricted viewers now get only the country populated, keeping the other contact details hidden.

## Testing
- Regular user viewing another user's profile now sees the country value.
- Sensitive contact fields (email, phone, address) remain hidden for restricted viewers.
- Full-access / own-profile views are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
