### PR TITLE
fix: update onFocus behavior for company and owner search fields

### DIFF
--- a/frontend/src/community/common/assets/languages/english/crmModule.json
+++ b/frontend/src/community/common/assets/languages/english/crmModule.json
@@ -29,7 +29,6 @@
         "owner": "Search contact owner"
       },
       "emptyStates": {
-        "noCompanies": "No companies found",
         "noOwners": "No contact owners found"
       },
       "buttons": {
@@ -99,7 +98,6 @@
         "owner": "Search contact owner"
       },
       "emptyStates": {
-        "noCompanies": "No companies found",
         "noOwners": "No contact owners found"
       },
       "buttons": {

--- a/frontend/src/community/crm/components/molecules/ContactModalForm/ContactModalForm.tsx
+++ b/frontend/src/community/crm/components/molecules/ContactModalForm/ContactModalForm.tsx
@@ -149,7 +149,7 @@ const ContactModalForm = ({
           onChange={(event) => setCompanySearchText(event.target.value)}
           onSelect={handleCompanySelect}
           onClose={() => setCompanySearchText("")}
-          isOpenOnFocus={isDomainSearchEnabled}
+          isOpenOnFocus={true}
           emptyMessage={
             isCompanyFetching ? undefined : (
               <p className="px-4 py-2 body2">

--- a/frontend/src/community/crm/components/molecules/ContactModalForm/ContactModalForm.tsx
+++ b/frontend/src/community/crm/components/molecules/ContactModalForm/ContactModalForm.tsx
@@ -149,9 +149,7 @@ const ContactModalForm = ({
           onChange={(event) => setCompanySearchText(event.target.value)}
           onSelect={handleCompanySelect}
           onClose={() => setCompanySearchText("")}
-          isOpenOnFocus={
-            isDomainSearchEnabled && !!domainSearchData?.companies?.length
-          }
+          isOpenOnFocus={isDomainSearchEnabled}
           emptyMessage={
             isCompanyFetching ? undefined : (
               <p className="px-4 py-2 body2">

--- a/frontend/src/community/crm/components/molecules/ContactModalForm/ContactModalForm.tsx
+++ b/frontend/src/community/crm/components/molecules/ContactModalForm/ContactModalForm.tsx
@@ -81,8 +81,10 @@ const ContactModalForm = ({
     isDomainSearchEnabled
   );
 
-  const { data: companyLookupData, isFetching: isCompanyFetching } =
-    useGetCompanyLookup(debouncedCompanySearch, DEFAULT_LOOKUP_PAGE_SIZE);
+  const { data: companyLookupData } = useGetCompanyLookup(
+    debouncedCompanySearch,
+    DEFAULT_LOOKUP_PAGE_SIZE
+  );
 
   const companyDropdownItems: SearchableDropdownItem[] = useMemo(
     () =>
@@ -150,13 +152,6 @@ const ContactModalForm = ({
           onSelect={handleCompanySelect}
           onClose={() => setCompanySearchText("")}
           isOpenOnFocus={true}
-          emptyMessage={
-            isCompanyFetching ? undefined : (
-              <p className="px-4 py-2 body2">
-                {translateContactText(["emptyStates", "noCompanies"])}
-              </p>
-            )
-          }
         />
       ) : (
         <InputField

--- a/frontend/src/community/crm/components/molecules/EditableContactOwnerField/EditableContactOwnerField.tsx
+++ b/frontend/src/community/crm/components/molecules/EditableContactOwnerField/EditableContactOwnerField.tsx
@@ -42,7 +42,7 @@ const EditableContactOwnerField = ({
   }, [initialOwner]);
 
   const { data: ownerLookupData, isFetching: isOwnerFetching } =
-    useGetOwnerLookup(debouncedOwnerSearch, DEFAULT_LOOKUP_PAGE_SIZE);
+    useGetOwnerLookup(debouncedOwnerSearch, DEFAULT_LOOKUP_PAGE_SIZE, true);
 
   const ownerDropdownItems: SearchableDropdownItem[] =
     ownerLookupData?.items?.map((owner) => ({
@@ -98,13 +98,11 @@ const EditableContactOwnerField = ({
       onChange={(event) => setOwnerSearchText(event.target.value)}
       state={errorMessage ? "error" : "default"}
       errorMessage={errorMessage}
-      isOpenOnFocus={!!ownerLookupData?.items?.length}
+      isOpenOnFocus
       emptyMessage={
-        isOwnerFetching ? undefined : (
-          <p className="px-4 py-2 body2">
-            {translateContactText(["emptyStates", "noOwners"])}
-          </p>
-        )
+        isOwnerFetching
+          ? undefined
+          : translateContactText(["emptyStates", "noOwners"])
       }
     />
   );

--- a/frontend/src/community/crm/components/molecules/EditableContactOwnerField/EditableContactOwnerField.tsx
+++ b/frontend/src/community/crm/components/molecules/EditableContactOwnerField/EditableContactOwnerField.tsx
@@ -98,6 +98,7 @@ const EditableContactOwnerField = ({
       onChange={(event) => setOwnerSearchText(event.target.value)}
       state={errorMessage ? "error" : "default"}
       errorMessage={errorMessage}
+      isOpenOnFocus={!!ownerLookupData?.items?.length}
       emptyMessage={
         isOwnerFetching ? undefined : (
           <p className="px-4 py-2 body2">


### PR DESCRIPTION
## PR checklist

### TaskId: (https://rootcode.skapp.com/pm/projects/CRM/items/414) 

### Summary

- In add contact form companies and owners should be visible on `onfocus ` without searching. 

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
