### PR TITLE
fix(leave): notify managers when employee cancels a leave request

### DIFF
--- a/backend/src/main/java/com/skapp/community/leaveplanner/service/impl/LeaveServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/service/impl/LeaveServiceImpl.java
@@ -442,6 +442,22 @@ public class LeaveServiceImpl implements LeaveService {
 
 		leaveRequest = leaveRequestDao.save(leaveRequest);
 
+		boolean isSingleDay = leaveRequest.getStartDate().equals(leaveRequest.getEndDate());
+		List<EmployeeManager> employeeManagers = employeeManagerDao.findByEmployee(currentUser.getEmployee());
+
+		leaveEmailService.sendCancelLeaveRequestEmployeeEmail(currentUser.getEmail(),
+				currentUser.getEmployee().getFirstName(), currentUser.getEmployee().getLastName(),
+				leaveRequest.getLeaveState().toString(), leaveRequest.getLeaveType().getName(),
+				leaveRequest.getStartDate(), leaveRequest.getEndDate(), isSingleDay);
+		leaveEmailService.sendCancelLeaveRequestManagerEmail(employeeManagers,
+				currentUser.getEmployee().getFirstName(), currentUser.getEmployee().getLastName(),
+				leaveRequest.getLeaveState().toString(), leaveRequest.getLeaveType().getName(),
+				leaveRequest.getStartDate(), leaveRequest.getEndDate(), isSingleDay);
+		leaveNotificationService.sendCancelLeaveRequestEmployeeNotification(currentUser.getEmployee(), employeeManagers,
+				leaveRequest, isSingleDay);
+		leaveNotificationService.sendCancelLeaveRequestManagerNotification(currentUser.getEmployee(), employeeManagers,
+				leaveRequest, isSingleDay);
+
 		LeaveRequestResponseDto leaveRequestResDto = leaveMapper.leaveRequestToLeaveRequestResponseDto(leaveRequest);
 
 		log.info("deleteLeaveRequestById: execution ended successfully for Leave Request: {}",


### PR DESCRIPTION
## Problem

When an employee cancels a leave request, the supervisor/manager does **not** receive an in-app notification or email.

## Root cause

The UI cancel action (`useCancelLeaveRequest`) issues an HTTP `DELETE` that maps to `LeaveServiceImpl.deleteLeaveRequestById`. Unlike the sibling `updateLeaveRequestByEmployee` path, this method set the leave status to `CANCELLED` but never dispatched any emails or notifications — so neither the employee nor their manager(s) were informed.

## Fix

After saving the cancelled request in `deleteLeaveRequestById`, send the cancel emails and notifications to both the employee and their manager(s), mirroring the existing `updateLeaveRequestByEmployee` path:

- `leaveEmailService.sendCancelLeaveRequestEmployeeEmail(...)`
- `leaveEmailService.sendCancelLeaveRequestManagerEmail(...)` — **email to manager(s)/supervisor**
- `leaveNotificationService.sendCancelLeaveRequestEmployeeNotification(...)`
- `leaveNotificationService.sendCancelLeaveRequestManagerNotification(...)` — **in-app notification to manager(s)/supervisor**

Managers are resolved via `employeeManagerDao.findByEmployee(...)`, and single- vs multi-day is derived the same way as the update path. All required beans were already injected.

The enterprise `EpLeaveServiceImpl.deleteLeaveRequestById` delegates to `super`, so it picks up the fix automatically.

## Testing

- [ ] Cancel a single-day leave request → employee + manager receive email and in-app notification
- [ ] Cancel a multi-day leave request → same

🤖 Generated with [Claude Code](https://claude.com/claude-code)
