### PR TITLE
fix: supervisor leave-cancellation notification content

### DIFF
--- a/backend/src/main/resources/community/templates/notification/notification-templates.json
+++ b/backend/src/main/resources/community/templates/notification/notification-templates.json
@@ -86,12 +86,12 @@
       {
         "id": "leave-module-manager-cancel-single-day-leave",
         "title": "Leave request canceled",
-        "message": "Your request for a {{leaveDuration}} {{leaveType}} leave on {{leaveStartDate}} has been canceled."
+        "message": "{{employeesName}}'s request for a {{leaveDuration}} {{leaveType}} leave on {{leaveStartDate}} has been canceled."
       },
       {
         "id": "leave-module-manager-cancel-multiple-day-leave",
         "title": "Leave request canceled",
-        "message": "Your request for a {{leaveDuration}} {{leaveType}} leave from {{leaveStartDate}} to {{leaveEndDate}} has been canceled."
+        "message": "{{employeesName}}'s request for a {{leaveDuration}} {{leaveType}} leave from {{leaveStartDate}} to {{leaveEndDate}} has been canceled."
       },
       {
         "id": "leave-module-employee-approved-single-day-leave",


### PR DESCRIPTION
## Problem

When an employee cancels their leave request, the supervisor's **in-app notification** was unusable. The two manager cancellation templates had been copied verbatim from the employee variants, so supervisors received:

> "Your request for a Full Day Casual leave on 2026-07-15 has been canceled."

— worded as if the supervisor's own leave was canceled, with no indication of which employee it belonged to. (The cancellation **email** to the supervisor was already correct; only the notification content was wrong.)

## Root cause

`NotificationServiceImpl.createNotification` renders content from `notification-templates.json` by template id. The manager-cancel entries used the employee phrasing and omitted the `{{employeesName}}` placeholder — even though `LeaveNotificationServiceImpl.sendCancelLeaveRequestManagerNotification` already supplies `employeesName`.

## Fix

Updated the two manager-cancel templates to use `{{employeesName}}` and manager-appropriate wording, consistent with the other manager notification templates (received / approved / revoked / declined):

- `leave-module-manager-cancel-single-day-leave`
- `leave-module-manager-cancel-multiple-day-leave`

No Java change required.

## Trigger path (for reviewers)

`DELETE`/`PATCH /v1/leave-requests/{id}` → `LeaveServiceImpl.sendCancelLeaveRequestEmailsAndNotifications` → `LeaveNotificationServiceImpl.sendCancelLeaveRequestManagerNotification` → `NotificationServiceImpl.createNotification` → renders `leave-module-manager-cancel-*`.

## Testing

Cancel a leave request as an employee; the assigned primary/secondary supervisor should now receive an in-app notification such as:

> "John Doe's request for a Full Day Casual leave on 2026-07-15 has been canceled."

🤖 Generated with [Claude Code](https://claude.com/claude-code)