### PR TITLE
refactor: enhance deal stage sorting and display logic

### DIFF
--- a/backend/src/main/java/com/skapp/community/crmplanner/service/impl/CrmDealServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/service/impl/CrmDealServiceImpl.java
@@ -236,8 +236,8 @@ public class CrmDealServiceImpl implements CrmDealService {
 	public ResponseEntityDto getBoardInitData() {
 		log.info("getBoardInitData: execution started");
 
-		List<CrmDealStage> visibleStages = filterVisibleDealStages(
-				crmDealStageDao.findAllByIsDeletedFalseOrderByOrderIndexAsc());
+		List<CrmDealStage> visibleStages = CrmUtil.sortStagesForDisplay(
+				filterVisibleDealStages(crmDealStageDao.findAllByIsDeletedFalseOrderByOrderIndexAsc()));
 		List<CrmBoardStageResponseDto> stages = crmMapper.crmDealStagesToCrmBoardStageResponseDtos(visibleStages);
 
 		List<CrmBoardContactResponseDto> contacts = crmContactDao.findAllContactsForBoardInit()

--- a/backend/src/main/java/com/skapp/community/crmplanner/service/impl/CrmDealStageServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/service/impl/CrmDealStageServiceImpl.java
@@ -14,6 +14,7 @@ import com.skapp.community.crmplanner.repository.CrmDealDao;
 import com.skapp.community.crmplanner.repository.CrmDealStageDao;
 import com.skapp.community.crmplanner.service.CrmDealStageService;
 import com.skapp.community.crmplanner.type.CrmDealStageType;
+import com.skapp.community.crmplanner.util.CrmUtil;
 import com.skapp.community.crmplanner.util.CrmValidations;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,8 +46,8 @@ public class CrmDealStageServiceImpl implements CrmDealStageService {
 	public ResponseEntityDto getDealStages() {
 		log.info("getDealStages: execution started");
 
-		List<CrmDealStage> stages = filterVisibleDealStages(
-				crmDealStageDao.findAllByIsDeletedFalseOrderByOrderIndexAsc());
+		List<CrmDealStage> stages = CrmUtil.sortStagesForDisplay(
+				filterVisibleDealStages(crmDealStageDao.findAllByIsDeletedFalseOrderByOrderIndexAsc()));
 
 		log.info("getDealStages: execution ended with {} result(s)", stages.size());
 
@@ -184,7 +185,8 @@ public class CrmDealStageServiceImpl implements CrmDealStageService {
 
 		log.info("reorderDealStages: execution ended");
 
-		return new ResponseEntityDto(false, crmMapper.crmDealStagesToCrmDealStageResponseDtos(existingStages));
+		return new ResponseEntityDto(false,
+				crmMapper.crmDealStagesToCrmDealStageResponseDtos(CrmUtil.sortStagesForDisplay(existingStages)));
 	}
 
 	private void updateStageTypesAfterReorder(List<CrmDealStage> reorderedStages) {

--- a/backend/src/main/java/com/skapp/community/crmplanner/type/CrmDealStageType.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/type/CrmDealStageType.java
@@ -1,7 +1,16 @@
 package com.skapp.community.crmplanner.type;
 
+import lombok.Getter;
+
+@Getter
 public enum CrmDealStageType {
 
-	INITIAL, OPEN, WON, LOST
+	INITIAL(1), OPEN(2), WON(3), LOST(4);
+
+	private final int displayOrder;
+
+	CrmDealStageType(int displayOrder) {
+		this.displayOrder = displayOrder;
+	}
 
 }

--- a/backend/src/main/java/com/skapp/community/crmplanner/util/CrmUtil.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/util/CrmUtil.java
@@ -6,6 +6,7 @@ import com.skapp.community.crmplanner.mapper.CrmMapper;
 import com.skapp.community.crmplanner.model.CrmCompany;
 import com.skapp.community.crmplanner.model.CrmContact;
 import com.skapp.community.crmplanner.model.CrmDeal;
+import com.skapp.community.crmplanner.model.CrmDealStage;
 import com.skapp.community.crmplanner.payload.response.CrmContactDetailResponseDto;
 import com.skapp.community.crmplanner.payload.response.CrmContactListItemDto;
 import com.skapp.community.crmplanner.payload.response.CrmContactLookupResponseDto;
@@ -15,8 +16,19 @@ import com.skapp.community.crmplanner.payload.response.board.CrmDealByStageItemR
 
 import lombok.experimental.UtilityClass;
 
+import java.util.Comparator;
+import java.util.List;
+
 @UtilityClass
 public class CrmUtil {
+
+	private static final Comparator<CrmDealStage> STAGE_DISPLAY_ORDER = Comparator
+		.comparingInt((CrmDealStage stage) -> stage.getStageType().getDisplayOrder())
+		.thenComparing(CrmDealStage::getOrderIndex);
+
+	public List<CrmDealStage> sortStagesForDisplay(List<CrmDealStage> stages) {
+		return stages.stream().sorted(STAGE_DISPLAY_ORDER).toList();
+	}
 
 	public boolean isCrmSalesRepresentative(User user) {
 		return user.getEmployee().getEmployeeRole().getCrmRole() == Role.CRM_SALES_REPRESENTATIVE;

--- a/backend/src/test/java/com/skapp/community/crmplanner/controller/v1/CrmDealStageControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/crmplanner/controller/v1/CrmDealStageControllerIntegrationTest.java
@@ -112,6 +112,22 @@ class CrmDealStageControllerIntegrationTest {
 	}
 
 	@Test
+	@DisplayName("Get deal stages after creating a stage - Returns new OPEN stage before WON and LOST")
+	void getDealStages_NewOpenStageWithHighestOrderIndex_ReturnsItBeforeTerminalStages() throws Exception {
+		performPostRequest(validPayload()).andExpect(status().isCreated());
+
+		performGetRequest().andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+			.andExpect(jsonPath("['results'].length()").value(8))
+			.andExpect(jsonPath("['results'][5]['name']").value("Proposal"))
+			.andExpect(jsonPath("['results'][5]['stageType']").value(CrmDealStageType.OPEN.name()))
+			.andExpect(jsonPath("['results'][5]['orderIndex']").value(8))
+			.andExpect(jsonPath("['results'][6]['name']").value(CrmDealStageName.WON.name()))
+			.andExpect(jsonPath("['results'][7]['name']").value(CrmDealStageName.LOST.name()));
+	}
+
+	@Test
 	@DisplayName("Get deal stages without CRM role - Returns Forbidden")
 	void getDealStages_WithoutCrmRole_ReturnsForbidden() throws Exception {
 		authToken = jwtService.generateAccessToken(userDetailsService.loadUserByUsername("user2@gmail.com"), 1L);


### PR DESCRIPTION
## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/[id]) 

### Summary

### Problem
Stage lists were sorted purely by `orderIndex`. Since `findNextOrderIndex()` assigns
max(orderIndex) + 1 across **all** stages, newly created open stages received a higher
index than the seeded Won/Lost stages — so they appeared **after** Won and Lost on the
board instead of between Initial and the terminal stages.

### Solution
Stages are now returned in a fixed display order: **Initial → Open (by order index) → Won → Lost.**

- `CrmDealStageType` now carries an explicit `displayOrder` field (`INITIAL(1), OPEN(2), WON(3), LOST(4)`),
  so the ordering is self-documenting and doesn't rely on enum declaration order.
- Added `CrmUtil.sortStagesForDisplay(...)`, which sorts by the type's display order first,
  then by `orderIndex` within the same type.
- Applied the sort at all stage-listing points:
  - `CrmDealServiceImpl.getBoardInitData()` — board init stages
  - `CrmDealStageServiceImpl.getDealStages()` — stage list endpoint
  - `CrmDealStageServiceImpl.reorderDealStages()` — response previously returned stages
    in their pre-reorder fetch order; now reflects the newly assigned order

### Notes
- Sorting is applied **after** `filterVisibleDealStages(...)`, so enterprise tier-visibility
  overrides are unaffected.
- No schema or data changes; ordering is handled in the service layer.

-

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
