### PR TITLE
fix: remove the task gate for deleted companies

### DIFF
--- a/backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmTaskRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmTaskRepositoryImpl.java
@@ -129,11 +129,8 @@ public class CrmTaskRepositoryImpl implements CrmTaskRepository {
 							cb.lessThan(task.get(CrmTask_.dueAt), cb.literal(LocalDate.now().atStartOfDay()))), 1L)
 					.otherwise(0L))));
 
-		Join<CrmTask, CrmCompany> companyJoin = task.join(CrmTask_.company, JoinType.LEFT);
-
 		query.where(task.get(CrmTask_.contact).get(CrmContact_.id).in(contactIds),
-				cb.isFalse(task.get(CrmTask_.isCompleted)), cb.isFalse(task.get(CrmTask_.isDeleted)),
-				cb.or(cb.isNull(companyJoin), cb.isFalse(companyJoin.get(CrmCompany_.isDeleted))));
+				cb.isFalse(task.get(CrmTask_.isCompleted)), cb.isFalse(task.get(CrmTask_.isDeleted)));
 
 		query.groupBy(task.get(CrmTask_.contact).get(CrmContact_.id));
 
@@ -151,14 +148,12 @@ public class CrmTaskRepositoryImpl implements CrmTaskRepository {
 		Join<CrmTask, CrmContact> directContact = task.join(CrmTask_.contact, JoinType.LEFT);
 		Join<CrmTask, CrmDeal> deal = task.join(CrmTask_.deal, JoinType.LEFT);
 		Join<CrmDeal, CrmContact> dealContact = deal.join(CrmDeal_.contact, JoinType.LEFT);
-		Join<CrmTask, CrmCompany> companyJoin = task.join(CrmTask_.company, JoinType.LEFT);
 
 		query.distinct(true);
 		query.where(cb.and(
 				cb.or(cb.equal(directContact.get(CrmContact_.id), contactId),
 						cb.equal(dealContact.get(CrmContact_.id), contactId)),
-				cb.isFalse(task.get(CrmTask_.isDeleted)),
-				cb.or(cb.isNull(companyJoin), cb.isFalse(companyJoin.get(CrmCompany_.isDeleted)))));
+				cb.isFalse(task.get(CrmTask_.isDeleted))));
 
 		return entityManager.createQuery(query).getResultList();
 	}
@@ -190,7 +185,6 @@ public class CrmTaskRepositoryImpl implements CrmTaskRepository {
 		Join<CrmTask, CrmContact> directContact = task.join(CrmTask_.contact, JoinType.LEFT);
 		Join<CrmTask, CrmDeal> deal = task.join(CrmTask_.deal, JoinType.LEFT);
 		Join<CrmDeal, CrmContact> dealContact = deal.join(CrmDeal_.contact, JoinType.LEFT);
-		Join<CrmTask, CrmCompany> companyJoin = task.join(CrmTask_.company, JoinType.LEFT);
 
 		Expression<Long> openCount = cb.coalesce(
 				cb.sum(cb.<Long>selectCase().when(cb.isFalse(task.get(CrmTask_.isCompleted)), 1L).otherwise(0L)), 0L);
@@ -205,8 +199,7 @@ public class CrmTaskRepositoryImpl implements CrmTaskRepository {
 		query.where(cb.and(
 				cb.or(cb.equal(directContact.get(CrmContact_.id), contactId),
 						cb.equal(dealContact.get(CrmContact_.id), contactId)),
-				cb.isFalse(task.get(CrmTask_.isDeleted)),
-				cb.or(cb.isNull(companyJoin), cb.isFalse(companyJoin.get(CrmCompany_.isDeleted)))));
+				cb.isFalse(task.get(CrmTask_.isDeleted))));
 
 		return entityManager.createQuery(query).getSingleResult();
 	}
@@ -215,9 +208,6 @@ public class CrmTaskRepositoryImpl implements CrmTaskRepository {
 		List<Predicate> predicates = new ArrayList<>();
 
 		predicates.add(cb.isFalse(root.get(CrmTask_.isDeleted)));
-
-		Join<CrmTask, CrmCompany> companyJoin = root.join(CrmTask_.company, JoinType.LEFT);
-		predicates.add(cb.or(cb.isNull(companyJoin), cb.isFalse(companyJoin.get(CrmCompany_.isDeleted))));
 
 		if (params.getCompleted() != null) {
 			predicates.add(Boolean.TRUE.equals(params.getCompleted()) ? cb.isTrue(root.get(CrmTask_.isCompleted))
@@ -248,6 +238,7 @@ public class CrmTaskRepositoryImpl implements CrmTaskRepository {
 		}
 
 		if (params.getCompanyId() != null) {
+			Join<CrmTask, CrmCompany> companyJoin = root.join(CrmTask_.company, JoinType.LEFT);
 			predicates.add(cb.equal(companyJoin.get(CrmCompany_.id), params.getCompanyId()));
 		}
 
@@ -325,12 +316,9 @@ public class CrmTaskRepositoryImpl implements CrmTaskRepository {
 		CriteriaQuery<Tuple> query = cb.createTupleQuery();
 		Root<CrmTask> task = query.from(CrmTask.class);
 
-		Join<CrmTask, CrmCompany> companyJoin = task.join(CrmTask_.company, JoinType.LEFT);
-
 		query.select(cb.tuple(task.get(CrmTask_.deal).get(CrmDeal_.id), cb.count(task.get(CrmTask_.id))));
 		query.where(task.get(CrmTask_.deal).get(CrmDeal_.id).in(dealIds), cb.isFalse(task.get(CrmTask_.isDeleted)),
-				cb.isFalse(task.get(CrmTask_.isCompleted)),
-				cb.or(cb.isNull(companyJoin), cb.isFalse(companyJoin.get(CrmCompany_.isDeleted))));
+				cb.isFalse(task.get(CrmTask_.isCompleted)));
 		query.groupBy(task.get(CrmTask_.deal).get(CrmDeal_.id));
 
 		Map<Long, Long> counts = new HashMap<>();

--- a/backend/src/test/java/com/skapp/community/crmplanner/controller/v1/CrmCompanyControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/crmplanner/controller/v1/CrmCompanyControllerIntegrationTest.java
@@ -1,28 +1,6 @@
 package com.skapp.community.crmplanner.controller.v1;
 
-import com.skapp.community.crmplanner.model.CrmContact;
-import com.skapp.community.crmplanner.model.CrmDeal;
-import com.skapp.community.crmplanner.model.CrmDealStage;
-import com.skapp.community.crmplanner.model.CrmTask;
-import com.skapp.community.crmplanner.model.CrmTaskType;
-import com.skapp.community.common.payload.response.PageDto;
-import com.skapp.community.crmplanner.payload.request.CrmContactMetricRequestDto;
-import com.skapp.community.crmplanner.payload.request.CrmDealFilterDto;
-import com.skapp.community.crmplanner.payload.request.CrmTaskFilterDto;
-import com.skapp.community.crmplanner.payload.response.CrmContactListItemDto;
-import com.skapp.community.crmplanner.payload.response.CrmDealResponseDto;
-import com.skapp.community.crmplanner.service.CrmContactService;
-import com.skapp.community.crmplanner.service.CrmDealService;
 import com.skapp.community.crmplanner.repository.CrmCompanyDao;
-import com.skapp.community.crmplanner.repository.CrmContactDao;
-import com.skapp.community.crmplanner.repository.CrmDealDao;
-import com.skapp.community.crmplanner.repository.CrmDealStageDao;
-import com.skapp.community.crmplanner.repository.CrmTaskDao;
-import com.skapp.community.crmplanner.repository.CrmTaskTypeDao;
-import com.skapp.community.crmplanner.type.CrmDealPriority;
-import com.skapp.community.crmplanner.type.CrmDealStageType;
-import com.skapp.community.crmplanner.type.CrmTaskPriority;
-import com.skapp.community.peopleplanner.repository.EmployeeDao;
 import com.skapp.TestSkappApplication;
 import com.skapp.community.common.service.JwtService;
 import com.skapp.community.common.util.MessageUtil;
@@ -42,7 +20,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.test.web.servlet.MockMvc;
@@ -93,22 +70,6 @@ class CrmCompanyControllerIntegrationTest {
 	private final MessageUtil messageUtil;
 
 	private final CrmCompanyDao crmCompanyDao;
-
-	private final CrmDealDao crmDealDao;
-
-	private final CrmDealStageDao crmDealStageDao;
-
-	private final CrmContactDao crmContactDao;
-
-	private final CrmTaskDao crmTaskDao;
-
-	private final CrmTaskTypeDao crmTaskTypeDao;
-
-	private final EmployeeDao employeeDao;
-
-	private final CrmContactService contactService;
-
-	private final CrmDealService dealService;
 
 	private String authToken;
 
@@ -272,97 +233,6 @@ class CrmCompanyControllerIntegrationTest {
 
 		// cleanup for future tests
 		crmCompanyDao.deleteById(companyId);
-	}
-
-	@Test
-	@DisplayName("Delete company with associated records - Keeps contacts and deals visible but hides tasks")
-	void deleteCompany_WithAssociatedRecords_KeepsContactsAndDealsVisibleButHidesTasks() throws Exception {
-		ResultActions createResult = performPostRequest(createValidPayload()).andExpect(status().isCreated());
-		Long companyId = objectMapper.readTree(createResult.andReturn().getResponse().getContentAsString())
-			.path("results")
-			.get(0)
-			.path("id")
-			.asLong();
-
-		CrmDealStage stage = new CrmDealStage();
-		stage.setName("Test Stage");
-		stage.setColor("#123456");
-		stage.setOrderIndex(1);
-		stage.setStageType(CrmDealStageType.OPEN);
-		crmDealStageDao.save(stage);
-
-		CrmContact contact = new CrmContact();
-		contact.setName("Test Contact");
-		contact.setEmail("deal.test@example.com");
-		contact.setOwner(employeeDao.getReferenceById(1L));
-		contact.setCompany(crmCompanyDao.getReferenceById(companyId));
-		Long contactId = crmContactDao.save(contact).getId();
-
-		CrmDeal deal = new CrmDeal();
-		deal.setName("Test Deal");
-		deal.setStage(stage);
-		deal.setCompany(crmCompanyDao.getReferenceById(companyId));
-		deal.setContact(contact);
-		deal.setOwner(employeeDao.getReferenceById(1L));
-		deal.setPriority(CrmDealPriority.MEDIUM);
-		deal.setOrderIndex("a0");
-		Long dealId = crmDealDao.save(deal).getId();
-
-		CrmTaskType taskType = new CrmTaskType();
-		taskType.setName("Test Task Type");
-		taskType.setOrderIndex(1);
-		crmTaskTypeDao.save(taskType);
-
-		CrmTask task = new CrmTask();
-		task.setName("Test Task");
-		task.setType(taskType);
-		task.setPriority(CrmTaskPriority.MEDIUM);
-		task.setOwner(employeeDao.getReferenceById(1L));
-		task.setCompany(crmCompanyDao.getReferenceById(companyId));
-		Long taskId = crmTaskDao.save(task).getId();
-
-		assertThat(crmDealDao.findDeals(new CrmDealFilterDto(), PageRequest.of(0, 100)).getContent())
-			.extracting(CrmDeal::getId)
-			.contains(dealId);
-		assertThat(crmContactDao.findContacts(new CrmContactMetricRequestDto(), PageRequest.of(0, 100)).getContent())
-			.extracting(CrmContact::getId)
-			.contains(contactId);
-		assertThat(crmTaskDao.findTasks(1L, new CrmTaskFilterDto())).extracting(CrmTask::getId).contains(taskId);
-
-		performDeleteRequest(companyId).andExpect(status().isOk())
-			.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
-			.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH)
-				.value(messageUtil.getMessage(CrmMessageConstant.CRM_SUCCESS_COMPANY_DELETED)));
-
-		CrmDeal remainingDeal = crmDealDao.findById(dealId).orElseThrow();
-		assertThat(remainingDeal.getIsDeleted()).isFalse();
-		CrmContact remainingContact = crmContactDao.findById(contactId).orElseThrow();
-		assertThat(remainingContact.getIsDeleted()).isFalse();
-		CrmTask remainingTask = crmTaskDao.findById(taskId).orElseThrow();
-		assertThat(remainingTask.getIsDeleted()).isFalse();
-
-		PageDto contactsPage = (PageDto) contactService.getContactMetrics(new CrmContactMetricRequestDto())
-			.getResults()
-			.get(0);
-		@SuppressWarnings("unchecked")
-		java.util.List<CrmContactListItemDto> contactItems = (java.util.List<CrmContactListItemDto>) contactsPage
-			.getItems();
-		assertThat(contactItems).filteredOn(c -> c.getId().equals(contactId))
-			.as("contact remains visible after its company is deleted")
-			.singleElement()
-			.satisfies(c -> assertThat(c.getCompany()).as("deleted company is presented as blank").isNull());
-
-		CrmDealFilterDto dealFilter = new CrmDealFilterDto();
-		dealFilter.setSize(100);
-		PageDto dealsPage = (PageDto) dealService.getDeals(dealFilter).getResults().get(0);
-		@SuppressWarnings("unchecked")
-		java.util.List<CrmDealResponseDto> dealItems = (java.util.List<CrmDealResponseDto>) dealsPage.getItems();
-		assertThat(dealItems).filteredOn(d -> d.getId().equals(dealId))
-			.as("deal remains visible after its company is deleted")
-			.singleElement()
-			.satisfies(d -> assertThat(d.getCompanyName()).as("deleted company is presented as blank").isNull());
-
-		assertThat(crmTaskDao.findTasks(1L, new CrmTaskFilterDto())).extracting(CrmTask::getId).doesNotContain(taskId);
 	}
 
 	@Test

--- a/backend/src/test/java/com/skapp/community/crmplanner/controller/v1/CrmCompanyControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/crmplanner/controller/v1/CrmCompanyControllerIntegrationTest.java
@@ -1,6 +1,28 @@
 package com.skapp.community.crmplanner.controller.v1;
 
+import com.skapp.community.crmplanner.model.CrmContact;
+import com.skapp.community.crmplanner.model.CrmDeal;
+import com.skapp.community.crmplanner.model.CrmDealStage;
+import com.skapp.community.crmplanner.model.CrmTask;
+import com.skapp.community.crmplanner.model.CrmTaskType;
+import com.skapp.community.common.payload.response.PageDto;
+import com.skapp.community.crmplanner.payload.request.CrmContactMetricRequestDto;
+import com.skapp.community.crmplanner.payload.request.CrmDealFilterDto;
+import com.skapp.community.crmplanner.payload.request.CrmTaskFilterDto;
+import com.skapp.community.crmplanner.payload.response.CrmContactListItemDto;
+import com.skapp.community.crmplanner.payload.response.CrmDealResponseDto;
+import com.skapp.community.crmplanner.service.CrmContactService;
+import com.skapp.community.crmplanner.service.CrmDealService;
 import com.skapp.community.crmplanner.repository.CrmCompanyDao;
+import com.skapp.community.crmplanner.repository.CrmContactDao;
+import com.skapp.community.crmplanner.repository.CrmDealDao;
+import com.skapp.community.crmplanner.repository.CrmDealStageDao;
+import com.skapp.community.crmplanner.repository.CrmTaskDao;
+import com.skapp.community.crmplanner.repository.CrmTaskTypeDao;
+import com.skapp.community.crmplanner.type.CrmDealPriority;
+import com.skapp.community.crmplanner.type.CrmDealStageType;
+import com.skapp.community.crmplanner.type.CrmTaskPriority;
+import com.skapp.community.peopleplanner.repository.EmployeeDao;
 import com.skapp.TestSkappApplication;
 import com.skapp.community.common.service.JwtService;
 import com.skapp.community.common.util.MessageUtil;
@@ -20,6 +42,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.test.web.servlet.MockMvc;
@@ -70,6 +93,22 @@ class CrmCompanyControllerIntegrationTest {
 	private final MessageUtil messageUtil;
 
 	private final CrmCompanyDao crmCompanyDao;
+
+	private final CrmDealDao crmDealDao;
+
+	private final CrmDealStageDao crmDealStageDao;
+
+	private final CrmContactDao crmContactDao;
+
+	private final CrmTaskDao crmTaskDao;
+
+	private final CrmTaskTypeDao crmTaskTypeDao;
+
+	private final EmployeeDao employeeDao;
+
+	private final CrmContactService contactService;
+
+	private final CrmDealService dealService;
 
 	private String authToken;
 
@@ -233,6 +272,113 @@ class CrmCompanyControllerIntegrationTest {
 
 		// cleanup for future tests
 		crmCompanyDao.deleteById(companyId);
+	}
+
+	@Test
+	@DisplayName("Delete company with associated records - Keeps contacts, deals and tasks visible")
+	void deleteCompany_WithAssociatedRecords_KeepsAllAssociatedRecordsVisible() throws Exception {
+		ResultActions createResult = performPostRequest(createValidPayload()).andExpect(status().isCreated());
+		Long companyId = objectMapper.readTree(createResult.andReturn().getResponse().getContentAsString())
+			.path("results")
+			.get(0)
+			.path("id")
+			.asLong();
+
+		CrmDealStage stage = new CrmDealStage();
+		stage.setName("Test Stage");
+		stage.setColor("#123456");
+		stage.setOrderIndex(1);
+		stage.setStageType(CrmDealStageType.OPEN);
+		crmDealStageDao.save(stage);
+
+		CrmContact contact = new CrmContact();
+		contact.setName("Test Contact");
+		contact.setEmail("deal.test@example.com");
+		contact.setOwner(employeeDao.getReferenceById(1L));
+		contact.setCompany(crmCompanyDao.getReferenceById(companyId));
+		Long contactId = crmContactDao.save(contact).getId();
+
+		CrmDeal deal = new CrmDeal();
+		deal.setName("Test Deal");
+		deal.setStage(stage);
+		deal.setCompany(crmCompanyDao.getReferenceById(companyId));
+		deal.setContact(contact);
+		deal.setOwner(employeeDao.getReferenceById(1L));
+		deal.setPriority(CrmDealPriority.MEDIUM);
+		deal.setOrderIndex("a0");
+		Long dealId = crmDealDao.save(deal).getId();
+
+		CrmTaskType taskType = new CrmTaskType();
+		taskType.setName("Test Task Type");
+		taskType.setOrderIndex(1);
+		crmTaskTypeDao.save(taskType);
+
+		CrmTask task = new CrmTask();
+		task.setName("Test Task");
+		task.setType(taskType);
+		task.setPriority(CrmTaskPriority.MEDIUM);
+		task.setOwner(employeeDao.getReferenceById(1L));
+		task.setContact(contact);
+		task.setDeal(deal);
+		task.setCompany(crmCompanyDao.getReferenceById(companyId));
+		Long taskId = crmTaskDao.save(task).getId();
+
+		assertThat(crmDealDao.findDeals(new CrmDealFilterDto(), PageRequest.of(0, 100)).getContent())
+			.extracting(CrmDeal::getId)
+			.contains(dealId);
+		assertThat(crmContactDao.findContacts(new CrmContactMetricRequestDto(), PageRequest.of(0, 100)).getContent())
+			.extracting(CrmContact::getId)
+			.contains(contactId);
+		assertThat(crmTaskDao.findTasks(1L, new CrmTaskFilterDto())).extracting(CrmTask::getId).contains(taskId);
+
+		performDeleteRequest(companyId).andExpect(status().isOk())
+			.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+			.andExpect(jsonPath(RESULTS_0_PATH + MESSAGE_PATH)
+				.value(messageUtil.getMessage(CrmMessageConstant.CRM_SUCCESS_COMPANY_DELETED)));
+
+		CrmDeal remainingDeal = crmDealDao.findById(dealId).orElseThrow();
+		assertThat(remainingDeal.getIsDeleted()).isFalse();
+		CrmContact remainingContact = crmContactDao.findById(contactId).orElseThrow();
+		assertThat(remainingContact.getIsDeleted()).isFalse();
+		CrmTask remainingTask = crmTaskDao.findById(taskId).orElseThrow();
+		assertThat(remainingTask.getIsDeleted()).isFalse();
+
+		PageDto contactsPage = (PageDto) contactService.getContactMetrics(new CrmContactMetricRequestDto())
+			.getResults()
+			.get(0);
+		@SuppressWarnings("unchecked")
+		java.util.List<CrmContactListItemDto> contactItems = (java.util.List<CrmContactListItemDto>) contactsPage
+			.getItems();
+		assertThat(contactItems).filteredOn(c -> c.getId().equals(contactId))
+			.as("contact remains visible after its company is deleted")
+			.singleElement()
+			.satisfies(c -> assertThat(c.getCompany()).as("deleted company is presented as blank").isNull());
+
+		CrmDealFilterDto dealFilter = new CrmDealFilterDto();
+		dealFilter.setSize(100);
+		PageDto dealsPage = (PageDto) dealService.getDeals(dealFilter).getResults().get(0);
+		@SuppressWarnings("unchecked")
+		java.util.List<CrmDealResponseDto> dealItems = (java.util.List<CrmDealResponseDto>) dealsPage.getItems();
+		assertThat(dealItems).filteredOn(d -> d.getId().equals(dealId))
+			.as("deal remains visible after its company is deleted")
+			.singleElement()
+			.satisfies(d -> assertThat(d.getCompanyName()).as("deleted company is presented as blank").isNull());
+
+		assertThat(crmTaskDao.findTasks(1L, new CrmTaskFilterDto()))
+			.as("task remains visible after its company is deleted")
+			.extracting(CrmTask::getId)
+			.contains(taskId);
+
+		assertThat(crmTaskDao.findTaskMetricsByContactId(contactId).getOpenTasksCount())
+			.as("contact task metrics still count tasks of a deleted company")
+			.isEqualTo(1L);
+		assertThat(crmTaskDao.findOpenTaskSummaryByContactIds(java.util.List.of(contactId)))
+			.as("open task summary still counts tasks of a deleted company")
+			.extracting(s -> s.getContactId())
+			.contains(contactId);
+		assertThat(crmTaskDao.countTasksByDealIds(java.util.List.of(dealId)))
+			.as("deal task count still counts tasks of a deleted company")
+			.containsEntry(dealId, 1L);
 	}
 
 	@Test


### PR DESCRIPTION
## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/[id]) 

### Summary

- Removed the deleted company filter from the tasks query to prevent tasks from disappearing when associated company is deleted.

### How to test

1.

### Project Checklist

- [x] Changes build without any errors
- [x] Have written adequate test cases
- [x] Done developer testing in
  - [x] Chrome
  - [ ] Firefox
  - [ ] Safari
- [x] Code is formatted with `npm run format`
- [x] Code is linted with `npm run check-lint`
- [x] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [x] Pull request is raised from the correct source branch
- [x] Pull request is raised to the correct destination branch
- [x] Pull request is raised with correct title
- [x] Pull request is self reviewed
- [x] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
