### PR TITLE
fix: Refactor the company name search to show exact matching on top

### DIFF
--- a/backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmCompanyRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmCompanyRepositoryImpl.java
@@ -137,7 +137,7 @@ public class CrmCompanyRepositoryImpl implements CrmCompanyRepository {
 		List<Order> orders = new ArrayList<>();
 
 		if (searchKeyword != null && !searchKeyword.isBlank()) {
-			String normalizedKeyword = searchKeyword.toLowerCase(Locale.ROOT);
+			String normalizedKeyword = searchKeyword.toLowerCase();
 			String escapedKeyword = StringUtils.escapeLikePattern(normalizedKeyword);
 			Expression<String> lowerName = cb.lower(company.get(CrmCompany_.name));
 

--- a/backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmCompanyRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmCompanyRepositoryImpl.java
@@ -124,7 +124,7 @@ public class CrmCompanyRepositoryImpl implements CrmCompanyRepository {
 		predicates.add(cb.isFalse(root.get(CrmCompany_.isDeleted)));
 
 		if (searchKeyword != null && !searchKeyword.isBlank()) {
-			String escapedKeyword = StringUtils.escapeLikePattern(searchKeyword.toLowerCase());
+			String escapedKeyword = StringUtils.escapeLikePattern(searchKeyword.toLowerCase(Locale.ROOT));
 
 			String likePattern = "%" + escapedKeyword + "%";
 			predicates.add(cb.like(cb.lower(root.get(CrmCompany_.name)), likePattern, '\\'));
@@ -137,7 +137,7 @@ public class CrmCompanyRepositoryImpl implements CrmCompanyRepository {
 		List<Order> orders = new ArrayList<>();
 
 		if (searchKeyword != null && !searchKeyword.isBlank()) {
-			String normalizedKeyword = searchKeyword.toLowerCase();
+			String normalizedKeyword = searchKeyword.toLowerCase(Locale.ROOT);
 			String escapedKeyword = StringUtils.escapeLikePattern(normalizedKeyword);
 			Expression<String> lowerName = cb.lower(company.get(CrmCompany_.name));
 
@@ -149,7 +149,7 @@ public class CrmCompanyRepositoryImpl implements CrmCompanyRepository {
 			orders.add(cb.asc(relevanceRank));
 		}
 
-		orders.add(cb.asc(company.get(CrmCompany_.name)));
+		orders.add(cb.asc(cb.lower(company.get(CrmCompany_.name))));
 		orders.add(cb.asc(company.get(CrmCompany_.id)));
 
 		return orders;

--- a/backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmCompanyRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmCompanyRepositoryImpl.java
@@ -28,7 +28,9 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.From;
+import jakarta.persistence.criteria.Order;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Subquery;
@@ -99,7 +101,7 @@ public class CrmCompanyRepositoryImpl implements CrmCompanyRepository {
 				accountValueSubquery.cast(String.class), closedCountSubquery, openCountSubquery));
 
 		query.where(buildPredicates(cb, company, searchKeyword));
-		query.orderBy(cb.asc(company.get(CrmCompany_.name)), cb.asc(company.get(CrmCompany_.id)));
+		query.orderBy(buildOrderBy(cb, company, searchKeyword));
 
 		List<CrmCompanyMetricsResponseDto> content = entityManager.createQuery(query)
 			.setFirstResult((int) pageable.getOffset())
@@ -122,13 +124,35 @@ public class CrmCompanyRepositoryImpl implements CrmCompanyRepository {
 		predicates.add(cb.isFalse(root.get(CrmCompany_.isDeleted)));
 
 		if (searchKeyword != null && !searchKeyword.isBlank()) {
-			String escapedKeyword = StringUtils.escapeLikePattern(searchKeyword);
+			String escapedKeyword = StringUtils.escapeLikePattern(searchKeyword.toLowerCase());
 
 			String likePattern = "%" + escapedKeyword + "%";
-			predicates.add(cb.like(cb.lower(root.get(CrmCompany_.name)), likePattern));
+			predicates.add(cb.like(cb.lower(root.get(CrmCompany_.name)), likePattern, '\\'));
 		}
 
 		return predicates.toArray(new Predicate[0]);
+	}
+
+	private List<Order> buildOrderBy(CriteriaBuilder cb, Root<CrmCompany> company, String searchKeyword) {
+		List<Order> orders = new ArrayList<>();
+
+		if (searchKeyword != null && !searchKeyword.isBlank()) {
+			String normalizedKeyword = searchKeyword.toLowerCase();
+			String escapedKeyword = StringUtils.escapeLikePattern(normalizedKeyword);
+			Expression<String> lowerName = cb.lower(company.get(CrmCompany_.name));
+
+			Expression<Integer> relevanceRank = cb.<Integer>selectCase()
+				.when(cb.equal(lowerName, normalizedKeyword), 0)
+				.when(cb.like(lowerName, escapedKeyword + "%", '\\'), 1)
+				.otherwise(2);
+
+			orders.add(cb.asc(relevanceRank));
+		}
+
+		orders.add(cb.asc(company.get(CrmCompany_.name)));
+		orders.add(cb.asc(company.get(CrmCompany_.id)));
+
+		return orders;
 	}
 
 	private List<Long> getClosedStageIds() {

--- a/backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmCompanyRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmCompanyRepositoryImpl.java
@@ -124,10 +124,10 @@ public class CrmCompanyRepositoryImpl implements CrmCompanyRepository {
 		predicates.add(cb.isFalse(root.get(CrmCompany_.isDeleted)));
 
 		if (searchKeyword != null && !searchKeyword.isBlank()) {
-			String escapedKeyword = StringUtils.escapeLikePattern(searchKeyword.toLowerCase(Locale.ROOT));
+			String escapedKeyword = StringUtils.escapeLikePattern(searchKeyword.toLowerCase());
 
 			String likePattern = "%" + escapedKeyword + "%";
-			predicates.add(cb.like(cb.lower(root.get(CrmCompany_.name)), likePattern, '\\'));
+			predicates.add(cb.like(cb.lower(root.get(CrmCompany_.name)), likePattern));
 		}
 
 		return predicates.toArray(new Predicate[0]);
@@ -143,14 +143,13 @@ public class CrmCompanyRepositoryImpl implements CrmCompanyRepository {
 
 			Expression<Integer> relevanceRank = cb.<Integer>selectCase()
 				.when(cb.equal(lowerName, normalizedKeyword), 0)
-				.when(cb.like(lowerName, escapedKeyword + "%", '\\'), 1)
+				.when(cb.like(lowerName, escapedKeyword + "%"), 1)
 				.otherwise(2);
 
 			orders.add(cb.asc(relevanceRank));
 		}
 
 		orders.add(cb.asc(cb.lower(company.get(CrmCompany_.name))));
-		orders.add(cb.asc(company.get(CrmCompany_.id)));
 
 		return orders;
 	}

--- a/backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmCompanyRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmCompanyRepositoryImpl.java
@@ -124,9 +124,7 @@ public class CrmCompanyRepositoryImpl implements CrmCompanyRepository {
 		predicates.add(cb.isFalse(root.get(CrmCompany_.isDeleted)));
 
 		if (searchKeyword != null && !searchKeyword.isBlank()) {
-			String escapedKeyword = StringUtils.escapeLikePattern(searchKeyword.toLowerCase());
-
-			String likePattern = "%" + escapedKeyword + "%";
+			String likePattern = "%" + escapedLowerKeyword(searchKeyword) + "%";
 			predicates.add(cb.like(cb.lower(root.get(CrmCompany_.name)), likePattern));
 		}
 
@@ -138,12 +136,11 @@ public class CrmCompanyRepositoryImpl implements CrmCompanyRepository {
 
 		if (searchKeyword != null && !searchKeyword.isBlank()) {
 			String normalizedKeyword = searchKeyword.toLowerCase();
-			String escapedKeyword = StringUtils.escapeLikePattern(normalizedKeyword);
 			Expression<String> lowerName = cb.lower(company.get(CrmCompany_.name));
 
 			Expression<Integer> relevanceRank = cb.<Integer>selectCase()
 				.when(cb.equal(lowerName, normalizedKeyword), 0)
-				.when(cb.like(lowerName, escapedKeyword + "%"), 1)
+				.when(cb.like(lowerName, escapedLowerKeyword(searchKeyword) + "%"), 1)
 				.otherwise(2);
 
 			orders.add(cb.asc(relevanceRank));
@@ -152,6 +149,10 @@ public class CrmCompanyRepositoryImpl implements CrmCompanyRepository {
 		orders.add(cb.asc(cb.lower(company.get(CrmCompany_.name))));
 
 		return orders;
+	}
+
+	private String escapedLowerKeyword(String searchKeyword) {
+		return StringUtils.escapeLikePattern(searchKeyword.toLowerCase());
 	}
 
 	private List<Long> getClosedStageIds() {

--- a/backend/src/test/java/com/skapp/community/crmplanner/controller/v1/CrmCompanyControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/crmplanner/controller/v1/CrmCompanyControllerIntegrationTest.java
@@ -584,6 +584,21 @@ class CrmCompanyControllerIntegrationTest {
 		assertThat(metrics.getOpenDeals()).as("LOST deals are not open, so open deal count is zero").isEqualTo(0L);
 	}
 
+	@Test
+	@DisplayName("Company metrics search ranks exact match, then prefix match, then contains match")
+	void getCompanyMetrics_RanksByRelevance() {
+		createMetricsCompany("Global Rankacme Partners");
+		createMetricsCompany("Rankacme Corp");
+		createMetricsCompany("Rankacme");
+
+		List<CrmCompanyMetricsResponseDto> metrics = crmCompanyDao.getCompanyMetrics(PageRequest.of(0, 100), "rankacme")
+			.getContent();
+
+		assertThat(metrics).extracting(CrmCompanyMetricsResponseDto::getName)
+			.as("exact match first, then prefix match, then contains match")
+			.containsExactly("Rankacme", "Rankacme Corp", "Global Rankacme Partners");
+	}
+
 	private CrmCompanyMetricsResponseDto fetchMetrics(Long companyId, String searchKeyword) {
 		List<CrmCompanyMetricsResponseDto> metrics = crmCompanyDao
 			.getCompanyMetrics(PageRequest.of(0, 100), searchKeyword)

--- a/frontend/src/community/common/assets/languages/english/crmModule.json
+++ b/frontend/src/community/common/assets/languages/english/crmModule.json
@@ -26,7 +26,7 @@
         "name": "Enter name",
         "email": "Enter email",
         "contactNumber": "Enter contact no.",
-        "company": "Search company",
+        "company": "Search by company name",
         "owner": "Search contact owner"
       },
       "emptyStates": {


### PR DESCRIPTION
Exact and prefix matches on company name now sort before partial matches when searching, and user-entered search text no longer breaks the SQL LIKE pattern when it contains wildcard characters.

## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/[id]) 

### Summary

-

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
