### PR TITLE
feat: Add router restriction for none Super Admin roles to access user role page and remove the "None" role from CRM row in user role page. 

### DIFF
--- a/backend/src/main/java/com/skapp/community/peopleplanner/service/impl/RolesServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/peopleplanner/service/impl/RolesServiceImpl.java
@@ -671,7 +671,6 @@ public class RolesServiceImpl implements RolesService {
 		if (moduleType == ModuleType.CRM) {
 			roles.add(RoleLevel.SALES_MANAGER.getDisplayName());
 			roles.add(RoleLevel.SALES_REPRESENTATIVE.getDisplayName());
-			roles.add(RoleLevel.NONE.getDisplayName());
 			return roles;
 		}
 		roles.add(RoleLevel.MANAGER.getDisplayName());

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -5,7 +5,8 @@ import { extractClaimsFromToken } from "~community/auth/utils/authUtils";
 import ROUTES, {
   employeeRestrictedRoutes,
   invoiceEmployeeRestrictedRoutes,
-  managerRestrictedRoutes
+  managerRestrictedRoutes,
+  userRolesRestrictedRoutes
 } from "~community/common/constants/routes";
 import {
   AdminTypes,
@@ -318,6 +319,15 @@ export function middleware(request: NextRequest) {
       roles
     );
     if (managerRedirect) return managerRedirect;
+
+    // Check user roles restricted routes (Super Admin only)
+    const userRolesRedirect = checkRestrictedRoutesAndRedirect(
+      request,
+      userRolesRestrictedRoutes,
+      ROLE_SUPER_ADMIN,
+      roles
+    );
+    if (userRolesRedirect) return userRolesRedirect;
 
     // Check invoice employee restricted routes
     const invoiceEmployeeRedirect = checkRestrictedRoutesAndRedirect(

--- a/frontend/src/community/common/constants/routes.ts
+++ b/frontend/src/community/common/constants/routes.ts
@@ -182,3 +182,5 @@ export const employeeRestrictedRoutes = [
 ];
 
 export const managerRestrictedRoutes = [ROUTES.PEOPLE.ADD];
+
+export const userRolesRestrictedRoutes = [ROUTES.CONFIGURATIONS.USER_ROLES];

--- a/frontend/src/community/configurations/components/molecules/UserRolesTable/UserRolesTable.tsx
+++ b/frontend/src/community/configurations/components/molecules/UserRolesTable/UserRolesTable.tsx
@@ -20,6 +20,8 @@ import { mapApiModuleToEnum } from "~community/configurations/utils/userRoles/ap
 
 import styles from "./styles";
 
+const CRM_NONE_ROLE_LABEL = "None";
+
 const UserRolesTable = (): JSX.Element => {
   const theme = useTheme();
   const classes = styles(theme);
@@ -63,7 +65,13 @@ const UserRolesTable = (): JSX.Element => {
 
           return {
             ...role,
-            name: moduleDisplayNames[moduleEnum]
+            name: moduleDisplayNames[moduleEnum],
+            roles:
+              moduleEnum === Modules.CRM
+                ? role.roles?.filter(
+                    (roleName) => roleName !== CRM_NONE_ROLE_LABEL //CRM NONE role should not show in the table even though it is present in the API response.
+                  )
+                : role.roles
           };
         });
       return formattedUserRoles;

--- a/frontend/src/community/configurations/components/molecules/UserRolesTable/UserRolesTable.tsx
+++ b/frontend/src/community/configurations/components/molecules/UserRolesTable/UserRolesTable.tsx
@@ -66,12 +66,7 @@ const UserRolesTable = (): JSX.Element => {
           return {
             ...role,
             name: moduleDisplayNames[moduleEnum],
-            roles:
-              moduleEnum === Modules.CRM
-                ? role.roles?.filter(
-                    (roleName) => roleName !== CRM_NONE_ROLE_LABEL //CRM NONE role should not show in the table even though it is present in the API response.
-                  )
-                : role.roles
+            roles: role.roles
           };
         });
       return formattedUserRoles;

--- a/frontend/src/community/configurations/components/molecules/UserRolesTable/UserRolesTable.tsx
+++ b/frontend/src/community/configurations/components/molecules/UserRolesTable/UserRolesTable.tsx
@@ -20,8 +20,6 @@ import { mapApiModuleToEnum } from "~community/configurations/utils/userRoles/ap
 
 import styles from "./styles";
 
-const CRM_NONE_ROLE_LABEL = "None";
-
 const UserRolesTable = (): JSX.Element => {
   const theme = useTheme();
   const classes = styles(theme);
@@ -65,8 +63,7 @@ const UserRolesTable = (): JSX.Element => {
 
           return {
             ...role,
-            name: moduleDisplayNames[moduleEnum],
-            roles: role.roles
+            name: moduleDisplayNames[moduleEnum]
           };
         });
       return formattedUserRoles;


### PR DESCRIPTION
…UserRolesTable

## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/[id]) 

### Summary

- The CRM User Roles page should display only the following roles: Admin,  Sales Manager, Sales Representative
- The "None" role option should not be displayed.
- Users without the required permissions should not be able to access the CRM User Roles page.
- The frontend should prevent unauthorised access by redirecting the user to an appropriate page.


### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
