### PR TITLE
feat(crm): integrate limit guard for adding deals in Kanban board

### DIFF
--- a/frontend/src/community/crm/components/molecules/DealStageLane/DealStageLane.tsx
+++ b/frontend/src/community/crm/components/molecules/DealStageLane/DealStageLane.tsx
@@ -26,6 +26,7 @@ export interface DealStageLaneProps {
   searchKeyword?: string;
   onDealClick: (dealId: number) => void;
   onAddDeal: (stageId: number) => void;
+  isAddDealDisabled?: boolean;
 }
 
 const DealStageLane: FC<DealStageLaneProps> = ({
@@ -38,7 +39,8 @@ const DealStageLane: FC<DealStageLaneProps> = ({
   isOver = false,
   searchKeyword,
   onDealClick,
-  onAddDeal
+  onAddDeal,
+  isAddDealDisabled = false
 }) => {
   const translateText = useTranslator("crmModule", "deals", "kanban");
 
@@ -98,6 +100,8 @@ const DealStageLane: FC<DealStageLaneProps> = ({
               icon={<PlusIcon />}
               iconPosition="end"
               onClick={() => onAddDeal(stage.id)}
+              disabled={isAddDealDisabled}
+              isLoading={isAddDealDisabled}
             >
               {translateText(["addDealBtn"])}
             </ButtonV2>

--- a/frontend/src/community/crm/components/organisms/DealsKanbanBoard/DealsKanbanBoard.tsx
+++ b/frontend/src/community/crm/components/organisms/DealsKanbanBoard/DealsKanbanBoard.tsx
@@ -49,7 +49,7 @@ const DealsKanbanBoard: FC<DealsKanbanBoardProps> = ({
   const { guardCrmCreate, isCheckingCrmLimit } = useCrmLimitGuard();
 
   const handleAddDeal = (stageId: number) => {
-    void guardCrmCreate(CrmLimitResource.DEALS, () => {
+    guardCrmCreate(CrmLimitResource.DEALS, () => {
       const { setPreselectedStageId, openCrmSidePanel } =
         useCrmStore.getState();
       setPreselectedStageId(stageId);

--- a/frontend/src/community/crm/components/organisms/DealsKanbanBoard/DealsKanbanBoard.tsx
+++ b/frontend/src/community/crm/components/organisms/DealsKanbanBoard/DealsKanbanBoard.tsx
@@ -16,6 +16,8 @@ import { useBoardData } from "~community/crm/hooks/useBoardData";
 import { useKanbanDrag } from "~community/crm/hooks/useKanbanDrag";
 import { useCrmStore } from "~community/crm/store/store";
 import { CrmSidePanelTypes } from "~community/crm/types/SidePanelTypes";
+import useCrmLimitGuard from "~enterprise/crm/hooks/useCrmLimitGuard";
+import { CrmLimitResource } from "~enterprise/crm/types/CrmLimitTypes";
 
 interface DealsKanbanBoardProps {
   searchKeyword?: string;
@@ -44,10 +46,15 @@ const DealsKanbanBoard: FC<DealsKanbanBoardProps> = ({
     handleDragEnd
   } = useKanbanDrag();
 
+  const { guardCrmCreate } = useCrmLimitGuard();
+
   const handleAddDeal = (stageId: number) => {
-    const { setPreselectedStageId, openCrmSidePanel } = useCrmStore.getState();
-    setPreselectedStageId(stageId);
-    openCrmSidePanel(CrmSidePanelTypes.ADD_DEAL_SIDE_PANEL);
+    guardCrmCreate(CrmLimitResource.DEALS, () => {
+      const { setPreselectedStageId, openCrmSidePanel } =
+        useCrmStore.getState();
+      setPreselectedStageId(stageId);
+      openCrmSidePanel(CrmSidePanelTypes.ADD_DEAL_SIDE_PANEL);
+    });
   };
 
   const handleDealClick = (dealId: number) => {

--- a/frontend/src/community/crm/components/organisms/DealsKanbanBoard/DealsKanbanBoard.tsx
+++ b/frontend/src/community/crm/components/organisms/DealsKanbanBoard/DealsKanbanBoard.tsx
@@ -46,7 +46,7 @@ const DealsKanbanBoard: FC<DealsKanbanBoardProps> = ({
     handleDragEnd
   } = useKanbanDrag();
 
-  const { guardCrmCreate } = useCrmLimitGuard();
+  const { guardCrmCreate, isCheckingCrmLimit } = useCrmLimitGuard();
 
   const handleAddDeal = (stageId: number) => {
     guardCrmCreate(CrmLimitResource.DEALS, () => {
@@ -90,6 +90,7 @@ const DealsKanbanBoard: FC<DealsKanbanBoardProps> = ({
                 searchKeyword={searchKeyword}
                 onDealClick={handleDealClick}
                 onAddDeal={handleAddDeal}
+                isAddDealDisabled={isCheckingCrmLimit}
               />
             );
           })}

--- a/frontend/src/community/crm/components/organisms/DealsKanbanBoard/DealsKanbanBoard.tsx
+++ b/frontend/src/community/crm/components/organisms/DealsKanbanBoard/DealsKanbanBoard.tsx
@@ -49,7 +49,7 @@ const DealsKanbanBoard: FC<DealsKanbanBoardProps> = ({
   const { guardCrmCreate, isCheckingCrmLimit } = useCrmLimitGuard();
 
   const handleAddDeal = (stageId: number) => {
-    guardCrmCreate(CrmLimitResource.DEALS, () => {
+    void guardCrmCreate(CrmLimitResource.DEALS, () => {
       const { setPreselectedStageId, openCrmSidePanel } =
         useCrmStore.getState();
       setPreselectedStageId(stageId);


### PR DESCRIPTION
## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/[id]) 

### Summary

- The upgrade limitation modal should be displayed when attempting to add a deal from the Swimlane View after reaching the free plan limit.

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
