### PR TITLE
[Fix] Downloaded release notes missing images in approver remarks

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -340,6 +340,13 @@
             <version>1.1.37</version>
         </dependency>
 
+        <!-- jsoup -->
+        <dependency>
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>1.21.2</version>
+        </dependency>
+
         <!-- Twilio -->
         <dependency>
             <groupId>com.twilio.sdk</groupId>


### PR DESCRIPTION
## Summary

Images added by approvers in their release remarks were missing from downloaded release notes. The remarks were passed through a regex tag-stripper that deleted `<img>` along with all other markup, so the images never reached the PDF renderer. Remarks are now sanitized with a jsoup allowlist that preserves rich text and images, and each image is resolved from the trusted PM CDN into an inline base64 data URI.

Fixes the DEV/Enterprise-Pro bug reported 2026/03/20.

## Root cause

`ReleaseServiceImpl.stripHtmlTags()` ran the approver's rich-text remarks through:

```java
String text = html.replaceAll("<[^>]*>", "");
```

That regex matches `<img …>` and deletes it outright — no placeholder, no URL, no alt text. The same call also collapsed `<p>A</p><p>B</p>` into `AB`, so multi-paragraph remarks ran together and lists/bold were lost.

A second problem sat behind it: the renderer is invoked as `builder.withHtmlContent(html, null)` — a null base URI with no `HttpStreamFactory` registered — so even if the `<img>` tags had survived, the remote CDN URLs would never have been fetched. Images must be inlined server-side.

## Changes in this repo (`SkappHQ/skapp`)

- `backend/pom.xml` — added `org.jsoup:jsoup:1.21.2`, used by the new `RichTextHtmlUtil` allowlist sanitizer in `skapp-ep-be-src`.
- Chosen over hand-rolled regex HTML handling: regex-based sanitization is a known-unsafe pattern, and jsoup also gives correct XML-syntax output, which openhtmltopdf requires.
- **This commit contains no submodule pointer bumps** — `backend/pom.xml` is the only file touched.

## Feature scope (all repos)

This fix spans multiple repos on branch `fix/release-note-remark-images`:

| Repo | What changed |
|------|--------------|
| `SkappHQ/skapp` (super) | Adds the `org.jsoup:jsoup:1.21.2` dependency |
| `rootcodelabs/skapp-ep-be-src` | `RichTextHtmlUtil` sanitizer, `PmRichTextService` image inliner, `PmCdnClientConfig` timeouts, `PmRichTextConstants`, `ReleaseServiceImpl` wiring |
| `rootcodelabs/skapp-ep-be-resources` | `release-note.html` remarks wrapper + scoped rich-text/image CSS |
| `rootcodelabs/skapp-ep-be-resources-config` | `pm.cdn.url` property in the non-prd and prd ep configs |

## Architecture / flow

```mermaid
flowchart TD
    A[FE: Download release note] --> B["core BE<br/>POST /v1/ep/release/generate-pdf"]
    B --> C["skapp-pm GraphQL<br/>internalProjectRelease"]
    C --> D["approver.remarks<br/>(rich HTML w/ CDN img src)"]
    D --> E["RichTextHtmlUtil.sanitize<br/>jsoup allowlist"]
    E --> F{"img host ==<br/>pm.cdn.url ?"}
    F -- no --> G["drop element"]
    F -- yes --> H["GET image<br/>3s connect / 10s read"]
    H --> I{"image mime +<br/>size <= 5MB ?"}
    I -- no --> G
    I -- yes --> J["inline as<br/>data:image/*;base64"]
    G --> K["openhtmltopdf render"]
    J --> K
    K --> L["PDF with remark images"]
```

**Before / after for a remark containing a screenshot:**

```mermaid
flowchart LR
    subgraph Before
      B1["&lt;p&gt;Looks &lt;b&gt;good&lt;/b&gt;&lt;/p&gt;&lt;img src=cdn/&gt;"] --> B2["regex strip"] --> B3["Looks good"]
    end
    subgraph After
      A1["&lt;p&gt;Looks &lt;b&gt;good&lt;/b&gt;&lt;/p&gt;&lt;img src=cdn/&gt;"] --> A2["sanitize + inline"] --> A3["formatted text + image"]
    end
```

## Security notes

The server now makes outbound HTTP requests to URLs that originate from user-authored content, so the fix applies the trusted-origin allowlist rule from `CLAUDE.md`:

- **Host allowlist** — only images whose host matches the configured `pm.cdn.url` are fetched. Everything else is dropped, so a crafted remark cannot make the backend hit an internal address (SSRF).
- **Timeouts** — a dedicated `RestTemplate` with 3s connect / 10s read, rather than the shared no-timeout bean, so a slow host cannot hang PDF generation.
- **Size and type caps** — 5 MB per image, max 20 images per field, and the response `Content-Type` must be `image/png|jpeg|gif|webp`.
- **XSS** — the previous code was safe only because it stripped everything. Now that markup is preserved, jsoup's allowlist is what neutralizes `<script>`, event handlers, and `javascript:` URLs.
- **Fail-open rendering** — a fetch failure drops that one image and logs; the PDF still renders rather than 500-ing.

## Verification

Verified by rendering the **real** `release-note.html` template through openhtmltopdf against a live local image server, then asserting on the resulting PDF with PDFBox:

| Assertion | Result |
|---|---|
| Trusted image inlined as `data:image/png;base64,` | pass |
| Image present as a PDF image XObject | pass |
| Untrusted-host image dropped | pass |
| `<script>` stripped | pass |
| Oversized `width="3000"` attribute removed, image scaled to content width | pass |
| Bold / list / paragraph formatting preserved | pass |
| Remark text extractable from the PDF | pass |

This caught a fatal regression that unit-level checks would have missed: **openhtmltopdf parses its input as strict XML**, and jsoup's default HTML output emits unclosed `<img>` tags. The first working version threw `SAXParseException: The element type "img" must be terminated by the matching end-tag "</img>"` and produced **no PDF at all** — turning "missing image" into a failed download. Fixed by setting jsoup's output syntax to XML.

## Exclusions — deliberately NOT in this PR

- **Release Summary/description has the identical defect.** `ReleaseServiceImpl` still calls `stripHtmlTags()` for the description and for work-item titles, so images and formatting are still lost there. Left out to keep this PR scoped to the reported bug; it is the same one-line swap if wanted as a follow-up.
- **Pre-existing formatting violation on `develop`** in `people/service/impl/EpProbationInternalServiceImpl.java` — `spring-javaformat:validate` currently fails on `develop` for this file, untouched by this change. Not fixed here to avoid unrelated churn, but it means the format gate is red on `develop` and worth a separate fix.
- Unrelated in-flight work in the local checkout (attendance-scheduler and OAuth-authorization-server changes, including an `spring-boot-starter-oauth2-authorization-server` line in the same `pom.xml`) was explicitly kept out; this branch was cut fresh from `origin/develop` in an isolated worktree and only the jsoup hunk was staged.

## Ignored — handled elsewhere / at deployment

- **Submodule hash / pointer bumps** are intentionally excluded. Gitlink updates are done at **deployment time**, not in feature PRs. The `SkappHQ/skapp` commit touches `backend/pom.xml` and nothing else.
- **`PM_CDN_URL` must be set in the core BE deployment environment.** This is a new variable for core (PM backend already has it). If it is unset or wrong, every remark image is silently dropped and the bug persists.

## Deployment note

The fix assumes the PM CDN serves these objects to an unauthenticated server-side `GET` — which is what the browser already does today when it renders the same `<img>` in the approval card UI. If that distribution turns out to be signed-cookie restricted in Enterprise-Pro, the fetch will 403 and images will drop silently; the fallback would be to resolve the S3 key from the stored URL and use `AmazonS3Service.downloadFileAsBytes` instead.

## Self-review findings (found and fixed before requesting review)

The change was reviewed adversarially against a live local origin server. Four real defects were found in the first implementation and fixed on this branch:

| # | Defect | Impact | Fix |
|---|--------|--------|-----|
| 1 | jsoup emits unclosed `<img>` by default; openhtmltopdf parses input as **strict XML** | `SAXParseException` — **no PDF produced at all**, turning "missing image" into a failed download | Set jsoup output syntax to XML |
| 2 | The per-field image cap counted **successes**, not attempts | A remark with N failing images issued N sequential fetches (each up to the 10s read timeout) — unbounded PDF-generation latency | Count attempts; outbound fetches now hard-capped at 20 |
| 3 | `getForEntity(…, byte[].class)` buffers the **whole** response before the 5 MB check | The size cap did not protect heap; a large object at a trusted path was fully read into memory first | Switched to a `ResponseExtractor` with `readNBytes(MAX + 1)` plus a `Content-Length` pre-check |
| 4 | Selector was `img[src]`, but jsoup strips a disallowed `javascript:` protocol and leaves the `<img>` **with no `src`** | Such an element bypassed the inliner entirely and reached the PDF as an empty image box | Selector widened to `img`; src-less elements are now dropped |

### Verification matrix

| Assertion | Result |
|---|---|
| Trusted image inlined as `data:image/png;base64,` and embedded as a PDF image XObject | pass |
| Untrusted host dropped | pass |
| SSRF: `http://169.254.169.254/…` (link-local) dropped | pass |
| Oversized image (6 MB vs 5 MB cap) dropped | pass |
| Non-image `Content-Type` dropped | pass |
| 404 dropped, PDF still rendered | pass |
| `<script>` stripped / `onclick` stripped / `javascript:` URI dropped | pass |
| `width="3000"` removed, image scaled to content width | pass |
| Bold, list and paragraph formatting preserved | pass |
| 50 failing images produce exactly **20** outbound fetches | pass |
| Content-free remark returns empty (no blank Remarks block); `null` safe | pass |

## Testing

| Check | Ran? | Result |
|-------|------|--------|
| Unit / integration tests (`mvn test`) | yes | **pass** — 597 tests, 0 failures, 0 errors, BUILD SUCCESS |
| Formatter (BE only) | yes | **pass for all changed files** — `spring-javaformat:apply` reformatted none of them. The suite gate is red only on the pre-existing `EpProbationInternalServiceImpl` violation already on `develop` (see Exclusions) |
| Checkstyle (BE only) | yes | **pass** |
| Compile | yes | **pass** |
| PDF render verification | yes | **pass** — see Verification table above |
| e2e (Playwright) | no | **not runnable** — the download flow needs core BE (:8080) and PM BE (:4000); both were down locally (only FE :3000 up). The PDF render verification above exercises the same code path end to end, including the real template |

## Related PRs

- SkappHQ/skapp#1687 — super repo: jsoup dependency (**merge together with the others; BE will not compile without it**)
- rootcodelabs/skapp-ep-be-src#731 — core of the fix: sanitizer, image inliner, service wiring
- rootcodelabs/skapp-ep-be-resources#290 — PDF template wrapper + rich-text/image CSS
- rootcodelabs/skapp-ep-be-resources-config#127 — `pm.cdn.url` property (**requires `PM_CDN_URL` in the core BE env**)

> These four must land together. Merging any subset leaves the backend either uncompilable (without #1687) or silently dropping every image (without #127 + the env var).
