### PR TITLE
feat: add breadcrumbs and common translations to CRM pages

### DIFF
--- a/frontend/pages/community/crm/companies.tsx
+++ b/frontend/pages/community/crm/companies.tsx
@@ -16,7 +16,7 @@ import { CrmLimitResource } from "~enterprise/crm/types/CrmLimitTypes";
 
 const Companies: NextPage = () => {
   const translateText = useTranslator("crmModule", "companies");
-  const translateCommonText = useTranslator("crmModule", "common");
+  const translateBreadcrumb = useTranslator("crmModule", "breadcrumbs");
   const { guardCrmCreate, isCheckingCrmLimit } = useCrmLimitGuard();
 
   const { setIsCompanyModalOpen, setCompanyModalType, selectedCompanyId } =
@@ -36,7 +36,7 @@ const Companies: NextPage = () => {
   return (
     <ContentLayout
       breadcrumbs={[
-        { label: translateCommonText(["crm"]) },
+        { label: translateBreadcrumb(["crm"]) },
         { label: translateText(["title"]) }
       ]}
       pageHead={translateText(["pageHead"])}

--- a/frontend/pages/community/crm/companies.tsx
+++ b/frontend/pages/community/crm/companies.tsx
@@ -15,8 +15,7 @@ import useCrmLimitGuard from "~enterprise/crm/hooks/useCrmLimitGuard";
 import { CrmLimitResource } from "~enterprise/crm/types/CrmLimitTypes";
 
 const Companies: NextPage = () => {
-  const translateText = useTranslator("crmModule", "companies");
-  const translateBreadcrumb = useTranslator("crmModule", "breadcrumbs");
+  const translateText = useTranslator("crmModule");
   const { guardCrmCreate, isCheckingCrmLimit } = useCrmLimitGuard();
 
   const { setIsCompanyModalOpen, setCompanyModalType, selectedCompanyId } =
@@ -36,12 +35,12 @@ const Companies: NextPage = () => {
   return (
     <ContentLayout
       breadcrumbs={[
-        { label: translateBreadcrumb(["crm"]) },
-        { label: translateText(["title"]) }
+        { label: translateText(["breadcrumbs.crm"]) },
+        { label: translateText(["companies.title"]) }
       ]}
-      pageHead={translateText(["pageHead"])}
-      title={translateText(["title"])}
-      primaryButtonText={translateText(["addCompanyBtn"])}
+      pageHead={translateText(["companies.pageHead"])}
+      title={translateText(["companies.title"])}
+      primaryButtonText={translateText(["companies.addCompanyBtn"])}
       primaryBtnIconName={IconName.ADD_ICON}
       onPrimaryButtonClick={onPrimaryButtonClick}
       isPrimaryBtnLoading={isCheckingCrmLimit}

--- a/frontend/pages/community/crm/companies.tsx
+++ b/frontend/pages/community/crm/companies.tsx
@@ -35,12 +35,12 @@ const Companies: NextPage = () => {
   return (
     <ContentLayout
       breadcrumbs={[
-        { label: translateText(["breadcrumbs.crm"]) },
-        { label: translateText(["companies.title"]) }
+        { label: translateText(["breadcrumbs", "crm"]) },
+        { label: translateText(["companies", "title"]) }
       ]}
-      pageHead={translateText(["companies.pageHead"])}
-      title={translateText(["companies.title"])}
-      primaryButtonText={translateText(["companies.addCompanyBtn"])}
+      pageHead={translateText(["companies", "pageHead"])}
+      title={translateText(["companies", "title"])}
+      primaryButtonText={translateText(["companies", "addCompanyBtn"])}
       primaryBtnIconName={IconName.ADD_ICON}
       onPrimaryButtonClick={onPrimaryButtonClick}
       isPrimaryBtnLoading={isCheckingCrmLimit}

--- a/frontend/pages/community/crm/companies.tsx
+++ b/frontend/pages/community/crm/companies.tsx
@@ -16,6 +16,7 @@ import { CrmLimitResource } from "~enterprise/crm/types/CrmLimitTypes";
 
 const Companies: NextPage = () => {
   const translateText = useTranslator("crmModule", "companies");
+  const translateCommonText = useTranslator("crmModule", "common");
   const { guardCrmCreate, isCheckingCrmLimit } = useCrmLimitGuard();
 
   const { setIsCompanyModalOpen, setCompanyModalType, selectedCompanyId } =
@@ -34,6 +35,10 @@ const Companies: NextPage = () => {
 
   return (
     <ContentLayout
+      breadcrumbs={[
+        { label: translateCommonText(["crm"]) },
+        { label: translateText(["title"]) }
+      ]}
       pageHead={translateText(["pageHead"])}
       title={translateText(["title"])}
       primaryButtonText={translateText(["addCompanyBtn"])}

--- a/frontend/pages/community/crm/contacts.tsx
+++ b/frontend/pages/community/crm/contacts.tsx
@@ -35,12 +35,12 @@ const Contacts: NextPage = () => {
   return (
     <ContentLayout
       breadcrumbs={[
-        { label: translateText(["breadcrumbs.crm"]) },
-        { label: translateText(["contacts.title"]) }
+        { label: translateText(["breadcrumbs", "crm"]) },
+        { label: translateText(["contacts", "title"]) }
       ]}
-      pageHead={translateText(["contacts.pageHead"])}
-      title={translateText(["contacts.title"])}
-      primaryButtonText={translateText(["contacts.addContactBtn"])}
+      pageHead={translateText(["contacts", "pageHead"])}
+      title={translateText(["contacts", "title"])}
+      primaryButtonText={translateText(["contacts", "addContactBtn"])}
       primaryBtnIconName={IconName.ADD_ICON}
       onPrimaryButtonClick={onPrimaryButtonClick}
       isPrimaryBtnLoading={isCheckingCrmLimit}

--- a/frontend/pages/community/crm/contacts.tsx
+++ b/frontend/pages/community/crm/contacts.tsx
@@ -15,8 +15,7 @@ import useCrmLimitGuard from "~enterprise/crm/hooks/useCrmLimitGuard";
 import { CrmLimitResource } from "~enterprise/crm/types/CrmLimitTypes";
 
 const Contacts: NextPage = () => {
-  const translateText = useTranslator("crmModule", "contacts");
-  const translateBreadcrumb = useTranslator("crmModule", "breadcrumbs");
+  const translateText = useTranslator("crmModule");
   const { guardCrmCreate, isCheckingCrmLimit } = useCrmLimitGuard();
 
   const { setIsContactModalOpen, setContactModalType, selectedContactId } =
@@ -36,12 +35,12 @@ const Contacts: NextPage = () => {
   return (
     <ContentLayout
       breadcrumbs={[
-        { label: translateBreadcrumb(["crm"]) },
-        { label: translateText(["title"]) }
+        { label: translateText(["breadcrumbs.crm"]) },
+        { label: translateText(["contacts.title"]) }
       ]}
-      pageHead={translateText(["pageHead"])}
-      title={translateText(["title"])}
-      primaryButtonText={translateText(["addContactBtn"])}
+      pageHead={translateText(["contacts.pageHead"])}
+      title={translateText(["contacts.title"])}
+      primaryButtonText={translateText(["contacts.addContactBtn"])}
       primaryBtnIconName={IconName.ADD_ICON}
       onPrimaryButtonClick={onPrimaryButtonClick}
       isPrimaryBtnLoading={isCheckingCrmLimit}

--- a/frontend/pages/community/crm/contacts.tsx
+++ b/frontend/pages/community/crm/contacts.tsx
@@ -16,6 +16,7 @@ import { CrmLimitResource } from "~enterprise/crm/types/CrmLimitTypes";
 
 const Contacts: NextPage = () => {
   const translateText = useTranslator("crmModule", "contacts");
+  const translateCommonText = useTranslator("crmModule", "common");
   const { guardCrmCreate, isCheckingCrmLimit } = useCrmLimitGuard();
 
   const { setIsContactModalOpen, setContactModalType, selectedContactId } =
@@ -34,6 +35,10 @@ const Contacts: NextPage = () => {
 
   return (
     <ContentLayout
+      breadcrumbs={[
+        { label: translateCommonText(["crm"]) },
+        { label: translateText(["title"]) }
+      ]}
       pageHead={translateText(["pageHead"])}
       title={translateText(["title"])}
       primaryButtonText={translateText(["addContactBtn"])}

--- a/frontend/pages/community/crm/contacts.tsx
+++ b/frontend/pages/community/crm/contacts.tsx
@@ -16,7 +16,7 @@ import { CrmLimitResource } from "~enterprise/crm/types/CrmLimitTypes";
 
 const Contacts: NextPage = () => {
   const translateText = useTranslator("crmModule", "contacts");
-  const translateCommonText = useTranslator("crmModule", "common");
+  const translateBreadcrumb = useTranslator("crmModule", "breadcrumbs");
   const { guardCrmCreate, isCheckingCrmLimit } = useCrmLimitGuard();
 
   const { setIsContactModalOpen, setContactModalType, selectedContactId } =
@@ -36,7 +36,7 @@ const Contacts: NextPage = () => {
   return (
     <ContentLayout
       breadcrumbs={[
-        { label: translateCommonText(["crm"]) },
+        { label: translateBreadcrumb(["crm"]) },
         { label: translateText(["title"]) }
       ]}
       pageHead={translateText(["pageHead"])}

--- a/frontend/pages/community/crm/deals.tsx
+++ b/frontend/pages/community/crm/deals.tsx
@@ -35,12 +35,12 @@ const Deals: NextPage = () => {
   return (
     <ContentLayout
       breadcrumbs={[
-        { label: translateText(["breadcrumbs.crm"]) },
-        { label: translateText(["deals.title"]) }
+        { label: translateText(["breadcrumbs", "crm"]) },
+        { label: translateText(["deals", "title"]) }
       ]}
-      pageHead={translateText(["deals.pageHead"])}
-      title={translateText(["deals.title"])}
-      primaryButtonText={translateText(["deals.addDealBtn"])}
+      pageHead={translateText(["deals", "pageHead"])}
+      title={translateText(["deals", "title"])}
+      primaryButtonText={translateText(["deals", "addDealBtn"])}
       primaryBtnIconName={IconName.ADD_ICON}
       isPrimaryBtnLoading={isCheckingCrmLimit}
       module={Modules.CRM}

--- a/frontend/pages/community/crm/deals.tsx
+++ b/frontend/pages/community/crm/deals.tsx
@@ -16,6 +16,7 @@ import { CrmLimitResource } from "~enterprise/crm/types/CrmLimitTypes";
 
 const Deals: NextPage = () => {
   const translateText = useTranslator("crmModule", "deals");
+  const translateCommonText = useTranslator("crmModule", "common");
   const { guardCrmCreate, isCheckingCrmLimit } = useCrmLimitGuard();
 
   const { openCrmSidePanel, selectedDealId, isCrmSidePanelOpen } = useCrmStore(
@@ -34,6 +35,10 @@ const Deals: NextPage = () => {
 
   return (
     <ContentLayout
+      breadcrumbs={[
+        { label: translateCommonText(["crm"]) },
+        { label: translateText(["title"]) }
+      ]}
       pageHead={translateText(["pageHead"])}
       title={translateText(["title"])}
       primaryButtonText={translateText(["addDealBtn"])}

--- a/frontend/pages/community/crm/deals.tsx
+++ b/frontend/pages/community/crm/deals.tsx
@@ -15,8 +15,7 @@ import useCrmLimitGuard from "~enterprise/crm/hooks/useCrmLimitGuard";
 import { CrmLimitResource } from "~enterprise/crm/types/CrmLimitTypes";
 
 const Deals: NextPage = () => {
-  const translateText = useTranslator("crmModule", "deals");
-  const translateBreadcrumb = useTranslator("crmModule", "breadcrumbs");
+  const translateText = useTranslator("crmModule");
   const { guardCrmCreate, isCheckingCrmLimit } = useCrmLimitGuard();
 
   const { openCrmSidePanel, selectedDealId, isCrmSidePanelOpen } = useCrmStore(
@@ -36,12 +35,12 @@ const Deals: NextPage = () => {
   return (
     <ContentLayout
       breadcrumbs={[
-        { label: translateBreadcrumb(["crm"]) },
-        { label: translateText(["title"]) }
+        { label: translateText(["breadcrumbs.crm"]) },
+        { label: translateText(["deals.title"]) }
       ]}
-      pageHead={translateText(["pageHead"])}
-      title={translateText(["title"])}
-      primaryButtonText={translateText(["addDealBtn"])}
+      pageHead={translateText(["deals.pageHead"])}
+      title={translateText(["deals.title"])}
+      primaryButtonText={translateText(["deals.addDealBtn"])}
       primaryBtnIconName={IconName.ADD_ICON}
       isPrimaryBtnLoading={isCheckingCrmLimit}
       module={Modules.CRM}

--- a/frontend/pages/community/crm/deals.tsx
+++ b/frontend/pages/community/crm/deals.tsx
@@ -16,7 +16,7 @@ import { CrmLimitResource } from "~enterprise/crm/types/CrmLimitTypes";
 
 const Deals: NextPage = () => {
   const translateText = useTranslator("crmModule", "deals");
-  const translateCommonText = useTranslator("crmModule", "common");
+  const translateBreadcrumb = useTranslator("crmModule", "breadcrumbs");
   const { guardCrmCreate, isCheckingCrmLimit } = useCrmLimitGuard();
 
   const { openCrmSidePanel, selectedDealId, isCrmSidePanelOpen } = useCrmStore(
@@ -36,7 +36,7 @@ const Deals: NextPage = () => {
   return (
     <ContentLayout
       breadcrumbs={[
-        { label: translateCommonText(["crm"]) },
+        { label: translateBreadcrumb(["crm"]) },
         { label: translateText(["title"]) }
       ]}
       pageHead={translateText(["pageHead"])}

--- a/frontend/pages/community/crm/tasks.tsx
+++ b/frontend/pages/community/crm/tasks.tsx
@@ -16,6 +16,7 @@ import { CrmLimitResource } from "~enterprise/crm/types/CrmLimitTypes";
 
 const Tasks: NextPage = () => {
   const translateText = useTranslator("crmModule", "tasks");
+  const translateCommonText = useTranslator("crmModule", "common");
   const containerRef = useRef<HTMLDivElement>(null);
   const { guardCrmCreate, isCheckingCrmLimit } = useCrmLimitGuard();
 
@@ -54,6 +55,10 @@ const Tasks: NextPage = () => {
 
   return (
     <ContentLayout
+      breadcrumbs={[
+        { label: translateCommonText(["crm"]) },
+        { label: translateText(["title"]) }
+      ]}
       pageHead={translateText(["pageHead"])}
       title={translateText(["title"])}
       primaryButtonText={translateText(["addTaskBtn"])}

--- a/frontend/pages/community/crm/tasks.tsx
+++ b/frontend/pages/community/crm/tasks.tsx
@@ -15,8 +15,7 @@ import useCrmLimitGuard from "~enterprise/crm/hooks/useCrmLimitGuard";
 import { CrmLimitResource } from "~enterprise/crm/types/CrmLimitTypes";
 
 const Tasks: NextPage = () => {
-  const translateText = useTranslator("crmModule", "tasks");
-  const translateBreadcrumb = useTranslator("crmModule", "breadcrumbs");
+  const translateText = useTranslator("crmModule");
   const containerRef = useRef<HTMLDivElement>(null);
   const { guardCrmCreate, isCheckingCrmLimit } = useCrmLimitGuard();
 
@@ -56,12 +55,12 @@ const Tasks: NextPage = () => {
   return (
     <ContentLayout
       breadcrumbs={[
-        { label: translateBreadcrumb(["crm"]) },
-        { label: translateText(["title"]) }
+        { label: translateText(["breadcrumbs.crm"]) },
+        { label: translateText(["tasks.title"]) }
       ]}
-      pageHead={translateText(["pageHead"])}
-      title={translateText(["title"])}
-      primaryButtonText={translateText(["addTaskBtn"])}
+      pageHead={translateText(["tasks.pageHead"])}
+      title={translateText(["tasks.title"])}
+      primaryButtonText={translateText(["tasks.addTaskBtn"])}
       primaryBtnIconName={IconName.ADD_ICON}
       containerStyles={{
         padding: { xs: "1.375rem 2rem 0", lg: "1.375rem 3rem 0" }

--- a/frontend/pages/community/crm/tasks.tsx
+++ b/frontend/pages/community/crm/tasks.tsx
@@ -55,12 +55,12 @@ const Tasks: NextPage = () => {
   return (
     <ContentLayout
       breadcrumbs={[
-        { label: translateText(["breadcrumbs.crm"]) },
-        { label: translateText(["tasks.title"]) }
+        { label: translateText(["breadcrumbs", "crm"]) },
+        { label: translateText(["tasks", "title"]) }
       ]}
-      pageHead={translateText(["tasks.pageHead"])}
-      title={translateText(["tasks.title"])}
-      primaryButtonText={translateText(["tasks.addTaskBtn"])}
+      pageHead={translateText(["tasks", "pageHead"])}
+      title={translateText(["tasks", "title"])}
+      primaryButtonText={translateText(["tasks", "addTaskBtn"])}
       primaryBtnIconName={IconName.ADD_ICON}
       containerStyles={{
         padding: { xs: "1.375rem 2rem 0", lg: "1.375rem 3rem 0" }

--- a/frontend/pages/community/crm/tasks.tsx
+++ b/frontend/pages/community/crm/tasks.tsx
@@ -16,7 +16,7 @@ import { CrmLimitResource } from "~enterprise/crm/types/CrmLimitTypes";
 
 const Tasks: NextPage = () => {
   const translateText = useTranslator("crmModule", "tasks");
-  const translateCommonText = useTranslator("crmModule", "common");
+  const translateBreadcrumb = useTranslator("crmModule", "breadcrumbs");
   const containerRef = useRef<HTMLDivElement>(null);
   const { guardCrmCreate, isCheckingCrmLimit } = useCrmLimitGuard();
 
@@ -56,7 +56,7 @@ const Tasks: NextPage = () => {
   return (
     <ContentLayout
       breadcrumbs={[
-        { label: translateCommonText(["crm"]) },
+        { label: translateBreadcrumb(["crm"]) },
         { label: translateText(["title"]) }
       ]}
       pageHead={translateText(["pageHead"])}

--- a/frontend/src/community/common/assets/languages/english/crmModule.json
+++ b/frontend/src/community/common/assets/languages/english/crmModule.json
@@ -1,11 +1,13 @@
 {
   "common": {
-    "crm": "CRM",
     "ownerPopupSearch": {
       "placeholder": "None",
       "searchPlaceholder": "Search Owner",
       "noResults": "No results"
     }
+  },
+  "breadcrumbs": {
+    "crm": "CRM"
   },
   "contacts": {
     "pageHead": "Contacts | Skapp",

--- a/frontend/src/community/common/assets/languages/english/crmModule.json
+++ b/frontend/src/community/common/assets/languages/english/crmModule.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "crm": "CRM",
     "ownerPopupSearch": {
       "placeholder": "None",
       "searchPlaceholder": "Search Owner",


### PR DESCRIPTION
## PR checklist

### TaskId: (https://rootcode.skapp.com/pm/projects/CRM/items/344) 

### Summary

## What
Added a static breadcrumb ("CRM / Contacts", "CRM / Companies", "CRM / Deals", "CRM / Tasks") to the top of each CRM list view.

## Why
Other modules (People, Leave, Timesheet, etc.) already show a breadcrumb so users know where they are. CRM didn't have one.

## Changes
- Added the `"crm": "CRM"` label under `common` in `crmModule.json`.
- Added a `breadcrumbs` prop to `ContentLayout` in `contacts.tsx`, `companies.tsx`, `deals.tsx`, `tasks.tsx`.
- Both segments are plain static text (no links), matching how other simple list-view breadcrumbs work across the app.

## Notes
- CRM has no detail pages (just side panels), so no entity names in the breadcrumb — kept it simple on purpose.
- Not tested in browser locally (needs backend + login), but code follows the exact same pattern used elsewhere (e.g. People Directory, Leave Requests).

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
