### PR TITLE
Fix/manual time entry email time mismatch

### DIFF
--- a/backend/src/main/java/com/skapp/community/common/service/OrganizationService.java
+++ b/backend/src/main/java/com/skapp/community/common/service/OrganizationService.java
@@ -24,6 +24,6 @@ public interface OrganizationService {
 
 	String getOrganizationTimeZone();
 
-	ZoneId getOrganizationTimeZoneInZoneId();
+	ZoneId getOrganizationZoneId();
 
 }

--- a/backend/src/main/java/com/skapp/community/common/service/OrganizationService.java
+++ b/backend/src/main/java/com/skapp/community/common/service/OrganizationService.java
@@ -6,6 +6,8 @@ import com.skapp.community.common.payload.request.UpdateOrganizationRequestDto;
 import com.skapp.community.common.payload.response.EmailServerConfigResponseDto;
 import com.skapp.community.common.payload.response.ResponseEntityDto;
 
+import java.time.ZoneId;
+
 public interface OrganizationService {
 
 	ResponseEntityDto saveOrganization(OrganizationDto organizationDto);
@@ -21,5 +23,7 @@ public interface OrganizationService {
 	ResponseEntityDto updateOrganization(UpdateOrganizationRequestDto organizationDto);
 
 	String getOrganizationTimeZone();
+
+	ZoneId getOrganizationTimeZoneInZoneId();
 
 }

--- a/backend/src/main/java/com/skapp/community/common/service/impl/OrganizationServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/common/service/impl/OrganizationServiceImpl.java
@@ -36,6 +36,7 @@ import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.ObjectNode;
 
 import java.time.DayOfWeek;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -225,6 +226,11 @@ public class OrganizationServiceImpl implements OrganizationService {
 		return organizationDao.findTopByOrderByOrganizationIdDesc()
 			.map(Organization::getOrganizationTimeZone)
 			.orElse("UTC");
+	}
+
+	@Override
+	public ZoneId getOrganizationTimeZoneInZoneId() {
+		return ZoneId.of(getOrganizationTimeZone());
 	}
 
 	public void getDefaultTimeConfigs() {

--- a/backend/src/main/java/com/skapp/community/common/service/impl/OrganizationServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/common/service/impl/OrganizationServiceImpl.java
@@ -19,6 +19,7 @@ import com.skapp.community.common.service.EncryptionDecryptionService;
 import com.skapp.community.common.service.OrganizationService;
 import com.skapp.community.common.service.UserService;
 import com.skapp.community.common.type.OrganizationConfigType;
+import com.skapp.community.common.util.DateTimeUtils;
 import com.skapp.community.common.util.MessageUtil;
 import com.skapp.community.crmplanner.service.CrmConfigService;
 import com.skapp.community.leaveplanner.service.LeaveCycleService;
@@ -229,8 +230,8 @@ public class OrganizationServiceImpl implements OrganizationService {
 	}
 
 	@Override
-	public ZoneId getOrganizationTimeZoneInZoneId() {
-		return ZoneId.of(getOrganizationTimeZone());
+	public ZoneId getOrganizationZoneId() {
+		return DateTimeUtils.resolveZoneId(getOrganizationTimeZone());
 	}
 
 	public void getDefaultTimeConfigs() {

--- a/backend/src/main/java/com/skapp/community/common/util/DateTimeUtils.java
+++ b/backend/src/main/java/com/skapp/community/common/util/DateTimeUtils.java
@@ -2,10 +2,12 @@ package com.skapp.community.common.util;
 
 import com.skapp.community.common.constant.CommonMessageConstant;
 import com.skapp.community.common.exception.ModuleException;
+import lombok.extern.slf4j.Slf4j;
 
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.DateTimeException;
 import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -26,8 +28,10 @@ import java.util.Set;
 import static org.aspectj.bridge.Version.SIMPLE_DATE_FORMAT;
 
 /**
- * Utility class for handling UTC date and time operations.
+ * Utility class for handling date and time operations, including both UTC-based and
+ * zone-parameterised formatting/conversion.
  */
+@Slf4j
 public class DateTimeUtils {
 
 	public static final int JANUARY = 1;
@@ -455,6 +459,25 @@ public class DateTimeUtils {
 		}
 		Set<String> validIDs = ZoneId.getAvailableZoneIds();
 		return validIDs.contains(timeZone);
+	}
+
+	/**
+	 * Resolves a time zone string to a ZoneId, falling back to UTC if the value is
+	 * null, blank, or not a valid zone ID.
+	 * @param timezone The time zone ID string to resolve.
+	 * @return The resolved ZoneId, or UTC if the input is invalid.
+	 */
+	public static ZoneId resolveZoneId(String timezone) {
+		if (timezone == null) {
+			return UTC_ZONE_ID;
+		}
+		try {
+			return ZoneId.of(timezone);
+		}
+		catch (DateTimeException e) {
+			log.warn("resolveZoneId: Invalid time zone '{}', falling back to UTC", timezone);
+			return UTC_ZONE_ID;
+		}
 	}
 
 	/**

--- a/backend/src/main/java/com/skapp/community/common/util/DateTimeUtils.java
+++ b/backend/src/main/java/com/skapp/community/common/util/DateTimeUtils.java
@@ -627,11 +627,7 @@ public class DateTimeUtils {
 	}
 
 	public static String epochMillisToAmPmString(Long epochMillis) {
-		if (epochMillis == null) {
-			throw new ModuleException(CommonMessageConstant.COMMON_ERROR_EPOCH_MILLIS_CANNOT_BE_NULL);
-		}
-		LocalTime time = Instant.ofEpochMilli(epochMillis).atZone(ZoneOffset.UTC).toLocalTime();
-		return time.format(AM_PM_FORMATTER);
+		return epochMillisToAmPmString(epochMillis, UTC_ZONE_ID);
 	}
 
 	public static String epochMillisToAmPmString(Long epochMillis, ZoneId zoneId) {

--- a/backend/src/main/java/com/skapp/community/common/util/DateTimeUtils.java
+++ b/backend/src/main/java/com/skapp/community/common/util/DateTimeUtils.java
@@ -634,6 +634,14 @@ public class DateTimeUtils {
 		return time.format(AM_PM_FORMATTER);
 	}
 
+	public static String epochMillisToAmPmString(Long epochMillis, ZoneId zoneId) {
+		if (epochMillis == null) {
+			throw new ModuleException(CommonMessageConstant.COMMON_ERROR_EPOCH_MILLIS_CANNOT_BE_NULL);
+		}
+		LocalTime time = Instant.ofEpochMilli(epochMillis).atZone(zoneId).toLocalTime();
+		return time.format(AM_PM_FORMATTER);
+	}
+
 	public static String formatDateWithSuffix(LocalDate date) {
 		int dayOfMonth = date.getDayOfMonth();
 		DateTimeFormatter monthFormatter = DateTimeFormatter.ofPattern("MMM", Locale.ENGLISH);

--- a/backend/src/main/java/com/skapp/community/common/util/DateTimeUtils.java
+++ b/backend/src/main/java/com/skapp/community/common/util/DateTimeUtils.java
@@ -28,10 +28,8 @@ import java.util.Set;
 import static org.aspectj.bridge.Version.SIMPLE_DATE_FORMAT;
 
 /**
- * Utility class for handling date and time operations, including both UTC-based and
- * zone-parameterised formatting/conversion.
+ * Utility class for handling UTC date and time operations.
  */
-@Slf4j
 public class DateTimeUtils {
 
 	public static final int JANUARY = 1;
@@ -462,8 +460,8 @@ public class DateTimeUtils {
 	}
 
 	/**
-	 * Resolves a time zone string to a ZoneId, falling back to UTC if the value is
-	 * null, blank, or not a valid zone ID.
+	 * Resolves a time zone string to a ZoneId, falling back to UTC if the value is null,
+	 * blank, or not a valid zone ID.
 	 * @param timezone The time zone ID string to resolve.
 	 * @return The resolved ZoneId, or UTC if the input is invalid.
 	 */
@@ -475,7 +473,6 @@ public class DateTimeUtils {
 			return ZoneId.of(timezone);
 		}
 		catch (DateTimeException e) {
-			log.warn("resolveZoneId: Invalid time zone '{}', falling back to UTC", timezone);
 			return UTC_ZONE_ID;
 		}
 	}

--- a/backend/src/main/java/com/skapp/community/timeplanner/service/impl/AttendanceNotificationServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/timeplanner/service/impl/AttendanceNotificationServiceImpl.java
@@ -2,6 +2,7 @@ package com.skapp.community.timeplanner.service.impl;
 
 import com.skapp.community.common.model.User;
 import com.skapp.community.common.service.NotificationService;
+import com.skapp.community.common.service.OrganizationService;
 import com.skapp.community.common.type.EmailBodyTemplates;
 import com.skapp.community.common.type.NotificationCategory;
 import com.skapp.community.common.type.NotificationType;
@@ -18,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Set;
 
@@ -30,11 +32,12 @@ public class AttendanceNotificationServiceImpl implements AttendanceNotification
 
 	private final EmployeeManagerDao employeeManagerDao;
 
+	private final OrganizationService organizationService;
+
 	@Override
 	public void sendTimeEntryRequestSubmittedEmployeeNotification(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields attendanceEmailDynamicFields = new AttendanceEmailDynamicFields();
-		attendanceEmailDynamicFields
-			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
+		setTimeEntryDate(attendanceEmailDynamicFields, timeRequest);
 
 		notificationService.createNotification(timeRequest.getEmployee(), timeRequest.getTimeRequestId().toString(),
 				NotificationType.TIME_ENTRY, EmailBodyTemplates.ATTENDANCE_MODULE_TIME_ENTRY_REQUEST_SUBMITTED_EMPLOYEE,
@@ -44,8 +47,7 @@ public class AttendanceNotificationServiceImpl implements AttendanceNotification
 	@Override
 	public void sendReceivedTimeEntryRequestManagerNotification(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields attendanceEmailDynamicFields = new AttendanceEmailDynamicFields();
-		attendanceEmailDynamicFields
-			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
+		setTimeEntryDate(attendanceEmailDynamicFields, timeRequest);
 		attendanceEmailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
 
@@ -59,8 +61,7 @@ public class AttendanceNotificationServiceImpl implements AttendanceNotification
 	@Override
 	public void sendTimeEntryRequestApprovedEmployeeNotification(TimeRequest timeRequest, User user) {
 		AttendanceEmailDynamicFields attendanceEmailDynamicFields = new AttendanceEmailDynamicFields();
-		attendanceEmailDynamicFields
-			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
+		setTimeEntryDate(attendanceEmailDynamicFields, timeRequest);
 
 		notificationService.createNotification(timeRequest.getEmployee(), timeRequest.getTimeRequestId().toString(),
 				NotificationType.TIME_ENTRY, EmailBodyTemplates.ATTENDANCE_MODULE_TIME_ENTRY_REQUEST_APPROVED_EMPLOYEE,
@@ -70,8 +71,7 @@ public class AttendanceNotificationServiceImpl implements AttendanceNotification
 	@Override
 	public void sendTimeEntryRequestDeclinedByManagerEmployeeNotification(TimeRequest timeRequest, User user) {
 		AttendanceEmailDynamicFields attendanceEmailDynamicFields = new AttendanceEmailDynamicFields();
-		attendanceEmailDynamicFields
-			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
+		setTimeEntryDate(attendanceEmailDynamicFields, timeRequest);
 
 		notificationService.createNotification(timeRequest.getEmployee(), timeRequest.getTimeRequestId().toString(),
 				NotificationType.TIME_ENTRY, EmailBodyTemplates.ATTENDANCE_MODULE_TIME_ENTRY_REQUEST_DECLINED_EMPLOYEE,
@@ -81,8 +81,7 @@ public class AttendanceNotificationServiceImpl implements AttendanceNotification
 	@Override
 	public void sendPendingTimeEntryRequestCancelledEmployeeNotification(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields attendanceEmailDynamicFields = new AttendanceEmailDynamicFields();
-		attendanceEmailDynamicFields
-			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
+		setTimeEntryDate(attendanceEmailDynamicFields, timeRequest);
 
 		notificationService.createNotification(timeRequest.getEmployee(), timeRequest.getTimeRequestId().toString(),
 				NotificationType.TIME_ENTRY,
@@ -93,8 +92,7 @@ public class AttendanceNotificationServiceImpl implements AttendanceNotification
 	@Override
 	public void sendPendingTimeEntryRequestCancelledManagerNotification(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields attendanceEmailDynamicFields = new AttendanceEmailDynamicFields();
-		attendanceEmailDynamicFields
-			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
+		setTimeEntryDate(attendanceEmailDynamicFields, timeRequest);
 		attendanceEmailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
 
@@ -108,8 +106,7 @@ public class AttendanceNotificationServiceImpl implements AttendanceNotification
 	@Override
 	public void sendTimeEntryRequestAutoApprovedEmployeeNotification(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields attendanceEmailDynamicFields = new AttendanceEmailDynamicFields();
-		attendanceEmailDynamicFields
-			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
+		setTimeEntryDate(attendanceEmailDynamicFields, timeRequest);
 
 		notificationService.createNotification(timeRequest.getEmployee(), timeRequest.getTimeRequestId().toString(),
 				NotificationType.TIME_ENTRY,
@@ -120,8 +117,7 @@ public class AttendanceNotificationServiceImpl implements AttendanceNotification
 	@Override
 	public void sendTimeEntryRequestAutoApprovedManagerNotification(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields attendanceEmailDynamicFields = new AttendanceEmailDynamicFields();
-		attendanceEmailDynamicFields
-			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
+		setTimeEntryDate(attendanceEmailDynamicFields, timeRequest);
 		attendanceEmailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
 
@@ -256,8 +252,7 @@ public class AttendanceNotificationServiceImpl implements AttendanceNotification
 		AttendanceEmailDynamicFields attendanceEmailDynamicFields = new AttendanceEmailDynamicFields();
 		attendanceEmailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
-		attendanceEmailDynamicFields
-			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
+		setTimeEntryDate(attendanceEmailDynamicFields, timeRequest);
 
 		List<EmployeeManager> otherManagers = getOtherManagers(
 				employeeManagerDao.findByEmployee(timeRequest.getEmployee()), user);
@@ -272,8 +267,7 @@ public class AttendanceNotificationServiceImpl implements AttendanceNotification
 		AttendanceEmailDynamicFields attendanceEmailDynamicFields = new AttendanceEmailDynamicFields();
 		attendanceEmailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
-		attendanceEmailDynamicFields
-			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
+		setTimeEntryDate(attendanceEmailDynamicFields, timeRequest);
 
 		List<EmployeeManager> otherManagers = getOtherManagers(
 				employeeManagerDao.findByEmployee(timeRequest.getEmployee()), user);
@@ -281,6 +275,12 @@ public class AttendanceNotificationServiceImpl implements AttendanceNotification
 		createAttendanceNotificationForManagers(otherManagers, timeRequest.getTimeRequestId().toString(),
 				attendanceEmailDynamicFields,
 				EmailBodyTemplates.ATTENDANCE_MODULE_TIME_ENTRY_REQUEST_DECLINED_OTHER_MANAGER);
+	}
+
+	private void setTimeEntryDate(AttendanceEmailDynamicFields fields, TimeRequest request) {
+		ZoneId zoneId = organizationService.getOrganizationZoneId();
+		fields.setTimeEntryDate(
+				DateTimeUtils.epochMillisToUtcLocalDateTime(request.getRequestedStartTime(), zoneId).toLocalDate().toString());
 	}
 
 	private List<EmployeeManager> getOtherManagers(List<EmployeeManager> allManagers, User currentManager) {

--- a/backend/src/main/java/com/skapp/community/timeplanner/service/impl/AttendanceNotificationServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/timeplanner/service/impl/AttendanceNotificationServiceImpl.java
@@ -279,8 +279,9 @@ public class AttendanceNotificationServiceImpl implements AttendanceNotification
 
 	private void setTimeEntryDate(AttendanceEmailDynamicFields fields, TimeRequest request) {
 		ZoneId zoneId = organizationService.getOrganizationZoneId();
-		fields.setTimeEntryDate(
-				DateTimeUtils.epochMillisToUtcLocalDateTime(request.getRequestedStartTime(), zoneId).toLocalDate().toString());
+		fields.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDateTime(request.getRequestedStartTime(), zoneId)
+			.toLocalDate()
+			.toString());
 	}
 
 	private List<EmployeeManager> getOtherManagers(List<EmployeeManager> allManagers, User currentManager) {

--- a/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeEmailServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeEmailServiceImpl.java
@@ -316,8 +316,9 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 
 	private void setTimeEntryFields(AttendanceEmailDynamicFields fields, TimeRequest request) {
 		ZoneId zoneId = organizationService.getOrganizationZoneId();
-		fields.setTimeEntryDate(
-				DateTimeUtils.epochMillisToUtcLocalDateTime(request.getRequestedStartTime(), zoneId).toLocalDate().toString());
+		fields.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDateTime(request.getRequestedStartTime(), zoneId)
+			.toLocalDate()
+			.toString());
 		fields.setStartTime(DateTimeUtils.epochMillisToAmPmString(request.getRequestedStartTime(), zoneId));
 		fields.setEndTime(DateTimeUtils.epochMillisToAmPmString(request.getRequestedEndTime(), zoneId));
 	}

--- a/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeEmailServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeEmailServiceImpl.java
@@ -172,15 +172,10 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestSubmittedEmployeeEmail(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
-		ZoneId zoneId = organizationService.getOrganizationTimeZoneInZoneId();
 
 		emailDynamicFields.setEmployeeOrManagerName(
 				timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
-		emailDynamicFields
-			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
-		emailDynamicFields
-			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime(), zoneId));
-		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime(), zoneId));
+		setTimeEntryFields(emailDynamicFields, timeRequest);
 
 		User user = timeRequest.getEmployee().getUser();
 
@@ -191,15 +186,10 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendReceivedTimeEntryRequestManagerEmail(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
-		ZoneId zoneId = organizationService.getOrganizationTimeZoneInZoneId();
 
 		emailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
-		emailDynamicFields
-			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
-		emailDynamicFields
-			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime(), zoneId));
-		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime(), zoneId));
+		setTimeEntryFields(emailDynamicFields, timeRequest);
 
 		List<EmployeeManager> managers = employeeManagerDao.findByEmployee(timeRequest.getEmployee());
 
@@ -211,16 +201,10 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestApprovedEmployeeEmail(TimeRequest timeRequestResponse, User managerUser) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
-		ZoneId zoneId = organizationService.getOrganizationTimeZoneInZoneId();
 
 		emailDynamicFields.setEmployeeOrManagerName(timeRequestResponse.getEmployee().getFirstName() + " "
 				+ timeRequestResponse.getEmployee().getLastName());
-		emailDynamicFields.setTimeEntryDate(
-				DateTimeUtils.epochMillisToUtcLocalDate(timeRequestResponse.getRequestedStartTime()).toString());
-		emailDynamicFields
-			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequestResponse.getRequestedStartTime(), zoneId));
-		emailDynamicFields
-			.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequestResponse.getRequestedEndTime(), zoneId));
+		setTimeEntryFields(emailDynamicFields, timeRequestResponse);
 		emailDynamicFields
 			.setManagerName(managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
 
@@ -231,16 +215,10 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestDeclinedEmployeeEmail(TimeRequest timeRequestResponse, User managerUser) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
-		ZoneId zoneId = organizationService.getOrganizationTimeZoneInZoneId();
 
 		emailDynamicFields.setEmployeeOrManagerName(timeRequestResponse.getEmployee().getFirstName() + " "
 				+ timeRequestResponse.getEmployee().getLastName());
-		emailDynamicFields.setTimeEntryDate(
-				DateTimeUtils.epochMillisToUtcLocalDate(timeRequestResponse.getRequestedStartTime()).toString());
-		emailDynamicFields
-			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequestResponse.getRequestedStartTime(), zoneId));
-		emailDynamicFields
-			.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequestResponse.getRequestedEndTime(), zoneId));
+		setTimeEntryFields(emailDynamicFields, timeRequestResponse);
 		emailDynamicFields
 			.setManagerName(managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
 
@@ -251,15 +229,10 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendPendingTimeEntryRequestCancelledEmployeeEmail(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
-		ZoneId zoneId = organizationService.getOrganizationTimeZoneInZoneId();
 
 		emailDynamicFields.setEmployeeOrManagerName(
 				timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
-		emailDynamicFields
-			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
-		emailDynamicFields
-			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime(), zoneId));
-		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime(), zoneId));
+		setTimeEntryFields(emailDynamicFields, timeRequest);
 
 		emailService.sendEmail(EmailBodyTemplates.ATTENDANCE_MODULE_PENDING_TIME_ENTRY_REQUEST_CANCELLED_EMPLOYEE,
 				emailDynamicFields, timeRequest.getEmployee().getUser().getEmail());
@@ -268,15 +241,10 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendPendingTimeEntryRequestCancelledManagerEmail(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
-		ZoneId zoneId = organizationService.getOrganizationTimeZoneInZoneId();
 
 		emailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
-		emailDynamicFields
-			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
-		emailDynamicFields
-			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime(), zoneId));
-		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime(), zoneId));
+		setTimeEntryFields(emailDynamicFields, timeRequest);
 
 		List<EmployeeManager> managers = employeeManagerDao.findByEmployee(timeRequest.getEmployee());
 
@@ -287,16 +255,10 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestAutoApprovedEmployeeEmail(TimeRequest timeRequestResponse) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
-		ZoneId zoneId = organizationService.getOrganizationTimeZoneInZoneId();
 
 		emailDynamicFields.setEmployeeOrManagerName(timeRequestResponse.getEmployee().getFirstName() + " "
 				+ timeRequestResponse.getEmployee().getLastName());
-		emailDynamicFields.setTimeEntryDate(
-				DateTimeUtils.epochMillisToUtcLocalDate(timeRequestResponse.getRequestedStartTime()).toString());
-		emailDynamicFields
-			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequestResponse.getRequestedStartTime(), zoneId));
-		emailDynamicFields
-			.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequestResponse.getRequestedEndTime(), zoneId));
+		setTimeEntryFields(emailDynamicFields, timeRequestResponse);
 
 		emailService.sendEmail(EmailBodyTemplates.ATTENDANCE_MODULE_TIME_ENTRY_REQUEST_AUTO_APPROVED_EMPLOYEE,
 				emailDynamicFields, timeRequestResponse.getEmployee().getUser().getEmail());
@@ -305,15 +267,10 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestAutoApprovedManagerEmail(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
-		ZoneId zoneId = organizationService.getOrganizationTimeZoneInZoneId();
 
 		emailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
-		emailDynamicFields
-			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
-		emailDynamicFields
-			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime(), zoneId));
-		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime(), zoneId));
+		setTimeEntryFields(emailDynamicFields, timeRequest);
 
 		List<EmployeeManager> managers = employeeManagerDao.findByEmployee(timeRequest.getEmployee());
 
@@ -324,13 +281,8 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestApprovedOtherManagerEmail(TimeRequest timeRequest, User managerUser) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
-		ZoneId zoneId = organizationService.getOrganizationTimeZoneInZoneId();
 
-		emailDynamicFields
-			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
-		emailDynamicFields
-			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime(), zoneId));
-		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime(), zoneId));
+		setTimeEntryFields(emailDynamicFields, timeRequest);
 		emailDynamicFields
 			.setManagerName(managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
 		emailDynamicFields
@@ -346,17 +298,12 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestDeclinedOtherManagerEmail(TimeRequest timeRequest, User managerUser) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
-		ZoneId zoneId = organizationService.getOrganizationTimeZoneInZoneId();
 
 		emailDynamicFields.setEmployeeOrManagerName(
 				managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
 		emailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
-		emailDynamicFields
-			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
-		emailDynamicFields
-			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime(), zoneId));
-		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime(), zoneId));
+		setTimeEntryFields(emailDynamicFields, timeRequest);
 		emailDynamicFields
 			.setManagerName(managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
 
@@ -365,6 +312,14 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 
 		createAttendanceEmailForManagers(otherManagers, emailDynamicFields,
 				EmailBodyTemplates.ATTENDANCE_MODULE_TIME_ENTRY_REQUEST_DECLINED_OTHER_MANAGER);
+	}
+
+	private void setTimeEntryFields(AttendanceEmailDynamicFields fields, TimeRequest request) {
+		ZoneId zoneId = organizationService.getOrganizationZoneId();
+		fields.setTimeEntryDate(
+				DateTimeUtils.epochMillisToUtcLocalDateTime(request.getRequestedStartTime(), zoneId).toLocalDate().toString());
+		fields.setStartTime(DateTimeUtils.epochMillisToAmPmString(request.getRequestedStartTime(), zoneId));
+		fields.setEndTime(DateTimeUtils.epochMillisToAmPmString(request.getRequestedEndTime(), zoneId));
 	}
 
 	private List<EmployeeManager> getOtherManagers(List<EmployeeManager> allManagers, User currentManager) {

--- a/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeEmailServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeEmailServiceImpl.java
@@ -2,6 +2,7 @@ package com.skapp.community.timeplanner.service.impl;
 
 import com.skapp.community.common.model.User;
 import com.skapp.community.common.service.EmailService;
+import com.skapp.community.common.service.OrganizationService;
 import com.skapp.community.common.type.EmailBodyTemplates;
 import com.skapp.community.common.util.DateTimeUtils;
 import com.skapp.community.leaveplanner.model.LeaveRequest;
@@ -16,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.time.ZoneId;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,6 +29,8 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	private final EmailService emailService;
 
 	private final EmployeeManagerDao employeeManagerDao;
+
+	private final OrganizationService organizationService;
 
 	@Override
 	public void sendNonWorkingDaySingleDayPendingLeaveRequestCancelEmployeeEmail(LeaveRequest leaveRequest) {
@@ -168,13 +172,15 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestSubmittedEmployeeEmail(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
+		ZoneId zoneId = getOrganizationZoneId();
 
 		emailDynamicFields.setEmployeeOrManagerName(
 				timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
 		emailDynamicFields
 			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
-		emailDynamicFields.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime()));
-		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime()));
+		emailDynamicFields
+			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime(), zoneId));
+		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime(), zoneId));
 
 		User user = timeRequest.getEmployee().getUser();
 
@@ -185,13 +191,15 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendReceivedTimeEntryRequestManagerEmail(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
+		ZoneId zoneId = getOrganizationZoneId();
 
 		emailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
 		emailDynamicFields
 			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
-		emailDynamicFields.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime()));
-		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime()));
+		emailDynamicFields
+			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime(), zoneId));
+		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime(), zoneId));
 
 		List<EmployeeManager> managers = employeeManagerDao.findByEmployee(timeRequest.getEmployee());
 
@@ -203,14 +211,16 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestApprovedEmployeeEmail(TimeRequest timeRequestResponse, User managerUser) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
+		ZoneId zoneId = getOrganizationZoneId();
 
 		emailDynamicFields.setEmployeeOrManagerName(timeRequestResponse.getEmployee().getFirstName() + " "
 				+ timeRequestResponse.getEmployee().getLastName());
 		emailDynamicFields.setTimeEntryDate(
 				DateTimeUtils.epochMillisToUtcLocalDate(timeRequestResponse.getRequestedStartTime()).toString());
 		emailDynamicFields
-			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequestResponse.getRequestedStartTime()));
-		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequestResponse.getRequestedEndTime()));
+			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequestResponse.getRequestedStartTime(), zoneId));
+		emailDynamicFields
+			.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequestResponse.getRequestedEndTime(), zoneId));
 		emailDynamicFields
 			.setManagerName(managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
 
@@ -221,14 +231,16 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestDeclinedEmployeeEmail(TimeRequest timeRequestResponse, User managerUser) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
+		ZoneId zoneId = getOrganizationZoneId();
 
 		emailDynamicFields.setEmployeeOrManagerName(timeRequestResponse.getEmployee().getFirstName() + " "
 				+ timeRequestResponse.getEmployee().getLastName());
 		emailDynamicFields.setTimeEntryDate(
 				DateTimeUtils.epochMillisToUtcLocalDate(timeRequestResponse.getRequestedStartTime()).toString());
 		emailDynamicFields
-			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequestResponse.getRequestedStartTime()));
-		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequestResponse.getRequestedEndTime()));
+			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequestResponse.getRequestedStartTime(), zoneId));
+		emailDynamicFields
+			.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequestResponse.getRequestedEndTime(), zoneId));
 		emailDynamicFields
 			.setManagerName(managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
 
@@ -239,13 +251,15 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendPendingTimeEntryRequestCancelledEmployeeEmail(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
+		ZoneId zoneId = getOrganizationZoneId();
 
 		emailDynamicFields.setEmployeeOrManagerName(
 				timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
 		emailDynamicFields
 			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
-		emailDynamicFields.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime()));
-		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime()));
+		emailDynamicFields
+			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime(), zoneId));
+		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime(), zoneId));
 
 		emailService.sendEmail(EmailBodyTemplates.ATTENDANCE_MODULE_PENDING_TIME_ENTRY_REQUEST_CANCELLED_EMPLOYEE,
 				emailDynamicFields, timeRequest.getEmployee().getUser().getEmail());
@@ -254,13 +268,15 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendPendingTimeEntryRequestCancelledManagerEmail(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
+		ZoneId zoneId = getOrganizationZoneId();
 
 		emailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
 		emailDynamicFields
 			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
-		emailDynamicFields.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime()));
-		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime()));
+		emailDynamicFields
+			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime(), zoneId));
+		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime(), zoneId));
 
 		List<EmployeeManager> managers = employeeManagerDao.findByEmployee(timeRequest.getEmployee());
 
@@ -271,14 +287,16 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestAutoApprovedEmployeeEmail(TimeRequest timeRequestResponse) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
+		ZoneId zoneId = getOrganizationZoneId();
 
 		emailDynamicFields.setEmployeeOrManagerName(timeRequestResponse.getEmployee().getFirstName() + " "
 				+ timeRequestResponse.getEmployee().getLastName());
 		emailDynamicFields.setTimeEntryDate(
 				DateTimeUtils.epochMillisToUtcLocalDate(timeRequestResponse.getRequestedStartTime()).toString());
 		emailDynamicFields
-			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequestResponse.getRequestedStartTime()));
-		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequestResponse.getRequestedEndTime()));
+			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequestResponse.getRequestedStartTime(), zoneId));
+		emailDynamicFields
+			.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequestResponse.getRequestedEndTime(), zoneId));
 
 		emailService.sendEmail(EmailBodyTemplates.ATTENDANCE_MODULE_TIME_ENTRY_REQUEST_AUTO_APPROVED_EMPLOYEE,
 				emailDynamicFields, timeRequestResponse.getEmployee().getUser().getEmail());
@@ -287,13 +305,15 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestAutoApprovedManagerEmail(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
+		ZoneId zoneId = getOrganizationZoneId();
 
 		emailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
 		emailDynamicFields
 			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
-		emailDynamicFields.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime()));
-		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime()));
+		emailDynamicFields
+			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime(), zoneId));
+		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime(), zoneId));
 
 		List<EmployeeManager> managers = employeeManagerDao.findByEmployee(timeRequest.getEmployee());
 
@@ -304,11 +324,13 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestApprovedOtherManagerEmail(TimeRequest timeRequest, User managerUser) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
+		ZoneId zoneId = getOrganizationZoneId();
 
 		emailDynamicFields
 			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
-		emailDynamicFields.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime()));
-		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime()));
+		emailDynamicFields
+			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime(), zoneId));
+		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime(), zoneId));
 		emailDynamicFields
 			.setManagerName(managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
 		emailDynamicFields
@@ -324,6 +346,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestDeclinedOtherManagerEmail(TimeRequest timeRequest, User managerUser) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
+		ZoneId zoneId = getOrganizationZoneId();
 
 		emailDynamicFields.setEmployeeOrManagerName(
 				managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
@@ -331,8 +354,9 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
 		emailDynamicFields
 			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
-		emailDynamicFields.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime()));
-		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime()));
+		emailDynamicFields
+			.setStartTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedStartTime(), zoneId));
+		emailDynamicFields.setEndTime(DateTimeUtils.epochMillisToAmPmString(timeRequest.getRequestedEndTime(), zoneId));
 		emailDynamicFields
 			.setManagerName(managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
 
@@ -357,6 +381,10 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 			emailService.sendEmail(emailBodyTemplates, attendanceEmailDynamicFields,
 					manager.getManager().getUser().getEmail());
 		});
+	}
+
+	private ZoneId getOrganizationZoneId() {
+		return ZoneId.of(organizationService.getOrganizationTimeZone());
 	}
 
 }

--- a/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeEmailServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeEmailServiceImpl.java
@@ -172,7 +172,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestSubmittedEmployeeEmail(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
-		ZoneId zoneId = getOrganizationZoneId();
+		ZoneId zoneId = organizationService.getOrganizationTimeZoneInZoneId();
 
 		emailDynamicFields.setEmployeeOrManagerName(
 				timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
@@ -191,7 +191,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendReceivedTimeEntryRequestManagerEmail(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
-		ZoneId zoneId = getOrganizationZoneId();
+		ZoneId zoneId = organizationService.getOrganizationTimeZoneInZoneId();
 
 		emailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
@@ -211,7 +211,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestApprovedEmployeeEmail(TimeRequest timeRequestResponse, User managerUser) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
-		ZoneId zoneId = getOrganizationZoneId();
+		ZoneId zoneId = organizationService.getOrganizationTimeZoneInZoneId();
 
 		emailDynamicFields.setEmployeeOrManagerName(timeRequestResponse.getEmployee().getFirstName() + " "
 				+ timeRequestResponse.getEmployee().getLastName());
@@ -231,7 +231,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestDeclinedEmployeeEmail(TimeRequest timeRequestResponse, User managerUser) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
-		ZoneId zoneId = getOrganizationZoneId();
+		ZoneId zoneId = organizationService.getOrganizationTimeZoneInZoneId();
 
 		emailDynamicFields.setEmployeeOrManagerName(timeRequestResponse.getEmployee().getFirstName() + " "
 				+ timeRequestResponse.getEmployee().getLastName());
@@ -251,7 +251,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendPendingTimeEntryRequestCancelledEmployeeEmail(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
-		ZoneId zoneId = getOrganizationZoneId();
+		ZoneId zoneId = organizationService.getOrganizationTimeZoneInZoneId();
 
 		emailDynamicFields.setEmployeeOrManagerName(
 				timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
@@ -268,7 +268,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendPendingTimeEntryRequestCancelledManagerEmail(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
-		ZoneId zoneId = getOrganizationZoneId();
+		ZoneId zoneId = organizationService.getOrganizationTimeZoneInZoneId();
 
 		emailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
@@ -287,7 +287,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestAutoApprovedEmployeeEmail(TimeRequest timeRequestResponse) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
-		ZoneId zoneId = getOrganizationZoneId();
+		ZoneId zoneId = organizationService.getOrganizationTimeZoneInZoneId();
 
 		emailDynamicFields.setEmployeeOrManagerName(timeRequestResponse.getEmployee().getFirstName() + " "
 				+ timeRequestResponse.getEmployee().getLastName());
@@ -305,7 +305,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestAutoApprovedManagerEmail(TimeRequest timeRequest) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
-		ZoneId zoneId = getOrganizationZoneId();
+		ZoneId zoneId = organizationService.getOrganizationTimeZoneInZoneId();
 
 		emailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
@@ -324,7 +324,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestApprovedOtherManagerEmail(TimeRequest timeRequest, User managerUser) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
-		ZoneId zoneId = getOrganizationZoneId();
+		ZoneId zoneId = organizationService.getOrganizationTimeZoneInZoneId();
 
 		emailDynamicFields
 			.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDate(timeRequest.getRequestedStartTime()).toString());
@@ -346,7 +346,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	@Override
 	public void sendTimeEntryRequestDeclinedOtherManagerEmail(TimeRequest timeRequest, User managerUser) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
-		ZoneId zoneId = getOrganizationZoneId();
+		ZoneId zoneId = organizationService.getOrganizationTimeZoneInZoneId();
 
 		emailDynamicFields.setEmployeeOrManagerName(
 				managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
@@ -381,10 +381,6 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 			emailService.sendEmail(emailBodyTemplates, attendanceEmailDynamicFields,
 					manager.getManager().getUser().getEmail());
 		});
-	}
-
-	private ZoneId getOrganizationZoneId() {
-		return ZoneId.of(organizationService.getOrganizationTimeZone());
 	}
 
 }

--- a/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeEmailServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeEmailServiceImpl.java
@@ -175,7 +175,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 
 		emailDynamicFields.setEmployeeOrManagerName(
 				timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
-		setTimeEntryDisplayFields(emailDynamicFields, timeRequest);
+		setEmailTimeEntryDateFields(emailDynamicFields, timeRequest);
 
 		User user = timeRequest.getEmployee().getUser();
 
@@ -189,7 +189,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 
 		emailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
-		setTimeEntryDisplayFields(emailDynamicFields, timeRequest);
+		setEmailTimeEntryDateFields(emailDynamicFields, timeRequest);
 
 		List<EmployeeManager> managers = employeeManagerDao.findByEmployee(timeRequest.getEmployee());
 
@@ -204,7 +204,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 
 		emailDynamicFields.setEmployeeOrManagerName(timeRequestResponse.getEmployee().getFirstName() + " "
 				+ timeRequestResponse.getEmployee().getLastName());
-		setTimeEntryDisplayFields(emailDynamicFields, timeRequestResponse);
+		setEmailTimeEntryDateFields(emailDynamicFields, timeRequestResponse);
 		emailDynamicFields
 			.setManagerName(managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
 
@@ -218,7 +218,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 
 		emailDynamicFields.setEmployeeOrManagerName(timeRequestResponse.getEmployee().getFirstName() + " "
 				+ timeRequestResponse.getEmployee().getLastName());
-		setTimeEntryDisplayFields(emailDynamicFields, timeRequestResponse);
+		setEmailTimeEntryDateFields(emailDynamicFields, timeRequestResponse);
 		emailDynamicFields
 			.setManagerName(managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
 
@@ -232,7 +232,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 
 		emailDynamicFields.setEmployeeOrManagerName(
 				timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
-		setTimeEntryDisplayFields(emailDynamicFields, timeRequest);
+		setEmailTimeEntryDateFields(emailDynamicFields, timeRequest);
 
 		emailService.sendEmail(EmailBodyTemplates.ATTENDANCE_MODULE_PENDING_TIME_ENTRY_REQUEST_CANCELLED_EMPLOYEE,
 				emailDynamicFields, timeRequest.getEmployee().getUser().getEmail());
@@ -244,7 +244,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 
 		emailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
-		setTimeEntryDisplayFields(emailDynamicFields, timeRequest);
+		setEmailTimeEntryDateFields(emailDynamicFields, timeRequest);
 
 		List<EmployeeManager> managers = employeeManagerDao.findByEmployee(timeRequest.getEmployee());
 
@@ -258,7 +258,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 
 		emailDynamicFields.setEmployeeOrManagerName(timeRequestResponse.getEmployee().getFirstName() + " "
 				+ timeRequestResponse.getEmployee().getLastName());
-		setTimeEntryDisplayFields(emailDynamicFields, timeRequestResponse);
+		setEmailTimeEntryDateFields(emailDynamicFields, timeRequestResponse);
 
 		emailService.sendEmail(EmailBodyTemplates.ATTENDANCE_MODULE_TIME_ENTRY_REQUEST_AUTO_APPROVED_EMPLOYEE,
 				emailDynamicFields, timeRequestResponse.getEmployee().getUser().getEmail());
@@ -270,7 +270,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 
 		emailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
-		setTimeEntryDisplayFields(emailDynamicFields, timeRequest);
+		setEmailTimeEntryDateFields(emailDynamicFields, timeRequest);
 
 		List<EmployeeManager> managers = employeeManagerDao.findByEmployee(timeRequest.getEmployee());
 
@@ -282,7 +282,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	public void sendTimeEntryRequestApprovedOtherManagerEmail(TimeRequest timeRequest, User managerUser) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
 
-		setTimeEntryDisplayFields(emailDynamicFields, timeRequest);
+		setEmailTimeEntryDateFields(emailDynamicFields, timeRequest);
 		emailDynamicFields
 			.setManagerName(managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
 		emailDynamicFields
@@ -303,7 +303,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 				managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
 		emailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
-		setTimeEntryDisplayFields(emailDynamicFields, timeRequest);
+		setEmailTimeEntryDateFields(emailDynamicFields, timeRequest);
 		emailDynamicFields
 			.setManagerName(managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
 
@@ -314,7 +314,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 				EmailBodyTemplates.ATTENDANCE_MODULE_TIME_ENTRY_REQUEST_DECLINED_OTHER_MANAGER);
 	}
 
-	private void setTimeEntryDisplayFields(AttendanceEmailDynamicFields fields, TimeRequest request) {
+	private void setEmailTimeEntryDateFields(AttendanceEmailDynamicFields fields, TimeRequest request) {
 		ZoneId zoneId = organizationService.getOrganizationZoneId();
 		fields.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDateTime(request.getRequestedStartTime(), zoneId)
 			.toLocalDate()

--- a/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeEmailServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/timeplanner/service/impl/TimeEmailServiceImpl.java
@@ -175,7 +175,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 
 		emailDynamicFields.setEmployeeOrManagerName(
 				timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
-		setTimeEntryFields(emailDynamicFields, timeRequest);
+		setTimeEntryDisplayFields(emailDynamicFields, timeRequest);
 
 		User user = timeRequest.getEmployee().getUser();
 
@@ -189,7 +189,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 
 		emailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
-		setTimeEntryFields(emailDynamicFields, timeRequest);
+		setTimeEntryDisplayFields(emailDynamicFields, timeRequest);
 
 		List<EmployeeManager> managers = employeeManagerDao.findByEmployee(timeRequest.getEmployee());
 
@@ -204,7 +204,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 
 		emailDynamicFields.setEmployeeOrManagerName(timeRequestResponse.getEmployee().getFirstName() + " "
 				+ timeRequestResponse.getEmployee().getLastName());
-		setTimeEntryFields(emailDynamicFields, timeRequestResponse);
+		setTimeEntryDisplayFields(emailDynamicFields, timeRequestResponse);
 		emailDynamicFields
 			.setManagerName(managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
 
@@ -218,7 +218,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 
 		emailDynamicFields.setEmployeeOrManagerName(timeRequestResponse.getEmployee().getFirstName() + " "
 				+ timeRequestResponse.getEmployee().getLastName());
-		setTimeEntryFields(emailDynamicFields, timeRequestResponse);
+		setTimeEntryDisplayFields(emailDynamicFields, timeRequestResponse);
 		emailDynamicFields
 			.setManagerName(managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
 
@@ -232,7 +232,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 
 		emailDynamicFields.setEmployeeOrManagerName(
 				timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
-		setTimeEntryFields(emailDynamicFields, timeRequest);
+		setTimeEntryDisplayFields(emailDynamicFields, timeRequest);
 
 		emailService.sendEmail(EmailBodyTemplates.ATTENDANCE_MODULE_PENDING_TIME_ENTRY_REQUEST_CANCELLED_EMPLOYEE,
 				emailDynamicFields, timeRequest.getEmployee().getUser().getEmail());
@@ -244,7 +244,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 
 		emailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
-		setTimeEntryFields(emailDynamicFields, timeRequest);
+		setTimeEntryDisplayFields(emailDynamicFields, timeRequest);
 
 		List<EmployeeManager> managers = employeeManagerDao.findByEmployee(timeRequest.getEmployee());
 
@@ -258,7 +258,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 
 		emailDynamicFields.setEmployeeOrManagerName(timeRequestResponse.getEmployee().getFirstName() + " "
 				+ timeRequestResponse.getEmployee().getLastName());
-		setTimeEntryFields(emailDynamicFields, timeRequestResponse);
+		setTimeEntryDisplayFields(emailDynamicFields, timeRequestResponse);
 
 		emailService.sendEmail(EmailBodyTemplates.ATTENDANCE_MODULE_TIME_ENTRY_REQUEST_AUTO_APPROVED_EMPLOYEE,
 				emailDynamicFields, timeRequestResponse.getEmployee().getUser().getEmail());
@@ -270,7 +270,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 
 		emailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
-		setTimeEntryFields(emailDynamicFields, timeRequest);
+		setTimeEntryDisplayFields(emailDynamicFields, timeRequest);
 
 		List<EmployeeManager> managers = employeeManagerDao.findByEmployee(timeRequest.getEmployee());
 
@@ -282,7 +282,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 	public void sendTimeEntryRequestApprovedOtherManagerEmail(TimeRequest timeRequest, User managerUser) {
 		AttendanceEmailDynamicFields emailDynamicFields = new AttendanceEmailDynamicFields();
 
-		setTimeEntryFields(emailDynamicFields, timeRequest);
+		setTimeEntryDisplayFields(emailDynamicFields, timeRequest);
 		emailDynamicFields
 			.setManagerName(managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
 		emailDynamicFields
@@ -303,7 +303,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 				managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
 		emailDynamicFields
 			.setEmployeeName(timeRequest.getEmployee().getFirstName() + " " + timeRequest.getEmployee().getLastName());
-		setTimeEntryFields(emailDynamicFields, timeRequest);
+		setTimeEntryDisplayFields(emailDynamicFields, timeRequest);
 		emailDynamicFields
 			.setManagerName(managerUser.getEmployee().getFirstName() + " " + managerUser.getEmployee().getLastName());
 
@@ -314,7 +314,7 @@ public class TimeEmailServiceImpl implements TimeEmailService {
 				EmailBodyTemplates.ATTENDANCE_MODULE_TIME_ENTRY_REQUEST_DECLINED_OTHER_MANAGER);
 	}
 
-	private void setTimeEntryFields(AttendanceEmailDynamicFields fields, TimeRequest request) {
+	private void setTimeEntryDisplayFields(AttendanceEmailDynamicFields fields, TimeRequest request) {
 		ZoneId zoneId = organizationService.getOrganizationZoneId();
 		fields.setTimeEntryDate(DateTimeUtils.epochMillisToUtcLocalDateTime(request.getRequestedStartTime(), zoneId)
 			.toLocalDate()


### PR DESCRIPTION
Bug: The time shown in the email body for a manual time entry request does not match the actual requested time, in both the supervisor's approval email and the requester's own email.

Root cause: The Time Entry Requests and Requests Awaiting Approval tables display times converted to the organization's configured time zone. However, the epochMillisToAmPmString() method in DateTimeUtils.java which is used when generating manual time entry request emails has the time zone hardcoded to UTC instead of using the organization's configured time zone. As a result, the time shown in the email body does not match the actual requested time or the time shown in the timesheet tables as the email have the UTC time.
