### PR TITLE
Fix crm 559 route restriction for crm none role

### DIFF
--- a/frontend/src/community/common/components/templates/BaseLayout/BaseLayout.tsx
+++ b/frontend/src/community/common/components/templates/BaseLayout/BaseLayout.tsx
@@ -8,6 +8,7 @@ import CommonModalController from "~community/common/components/organisms/Common
 import ContentWithDrawer from "~community/common/components/organisms/ContentWithDrawer/ContentWithDrawer";
 import ContentWithoutDrawer from "~community/common/components/organisms/ContentWithoutDrawer/ContentWithoutDrawer";
 import { appModes } from "~community/common/constants/configs";
+import useModuleAccessGuard from "~community/common/hooks/useModuleAccessGuard";
 import useSessionData from "~community/common/hooks/useSessionData";
 import { tenantID } from "~community/common/utils/axiosInterceptor";
 import { setDeviceToken } from "~enterprise/common/api/setDeviceTokenApi";
@@ -25,6 +26,8 @@ const BaseLayout = ({ children }: Props) => {
   const { asPath } = useRouter();
 
   const { sessionStatus } = useSessionData();
+
+  useModuleAccessGuard();
 
   const { token } = useFcmToken();
 

--- a/frontend/src/community/common/constants/routes.ts
+++ b/frontend/src/community/common/constants/routes.ts
@@ -193,14 +193,6 @@ export const managerRestrictedRoutes = [ROUTES.PEOPLE.ADD];
 
 export const userRolesRestrictedRoutes = [ROUTES.CONFIGURATIONS.USER_ROLES];
 
-/**
- * The base role each module's routes require, mirroring the module gates
- * `getDrawerRoutes` already applies when it hides a module from the drawer.
- *
- * `middleware.ts` cannot enforce these while the user stays inside the app, since
- * client side navigations never reach the edge. `useModuleAccessGuard` applies them
- * whenever the roles change.
- */
 export const moduleGuardedRoutes: {
   routes: string[];
   requiredRole: EmployeeTypes | ManagerTypes | RepresentativeTypes;

--- a/frontend/src/community/common/constants/routes.ts
+++ b/frontend/src/community/common/constants/routes.ts
@@ -1,3 +1,9 @@
+import {
+  EmployeeTypes,
+  ManagerTypes,
+  RepresentativeTypes
+} from "~community/common/types/AuthTypes";
+
 const ROUTES = {
   AUTH: {
     SIGNUP: "/signup",
@@ -186,3 +192,41 @@ export const employeeRestrictedRoutes = [
 export const managerRestrictedRoutes = [ROUTES.PEOPLE.ADD];
 
 export const userRolesRestrictedRoutes = [ROUTES.CONFIGURATIONS.USER_ROLES];
+
+/**
+ * The base role each module's routes require, mirroring the module gates
+ * `getDrawerRoutes` already applies when it hides a module from the drawer.
+ *
+ * `middleware.ts` cannot enforce these while the user stays inside the app, since
+ * client side navigations never reach the edge. `useModuleAccessGuard` applies them
+ * whenever the roles change.
+ */
+export const moduleGuardedRoutes: {
+  routes: string[];
+  requiredRole: EmployeeTypes | ManagerTypes | RepresentativeTypes;
+}[] = [
+  {
+    routes: [ROUTES.CRM.BASE],
+    requiredRole: RepresentativeTypes.CRM_SALES_REPRESENTATIVE
+  },
+  {
+    routes: [ROUTES.INVOICE.BASE],
+    requiredRole: ManagerTypes.INVOICE_MANAGER
+  },
+  {
+    routes: [
+      ROUTES.PROJECTS.BASE,
+      ROUTES.PROJECTS.GUESTS,
+      ROUTES.PROJECTS.GUEST_REQUESTS
+    ],
+    requiredRole: EmployeeTypes.PM_EMPLOYEE
+  },
+  {
+    routes: [ROUTES.LEAVE.BASE],
+    requiredRole: EmployeeTypes.LEAVE_EMPLOYEE
+  },
+  {
+    routes: [ROUTES.TIMESHEET.BASE],
+    requiredRole: EmployeeTypes.ATTENDANCE_EMPLOYEE
+  }
+];

--- a/frontend/src/community/common/hooks/useModuleAccessGuard.ts
+++ b/frontend/src/community/common/hooks/useModuleAccessGuard.ts
@@ -1,0 +1,39 @@
+import { useRouter } from "next/router";
+import { useEffect } from "react";
+
+import { useAuth } from "~community/auth/providers/AuthProvider";
+import ROUTES from "~community/common/constants/routes";
+import { isModuleRouteRestricted } from "~community/common/utils/commonUtil";
+
+/**
+ * Re-checks module access on the client whenever the user's roles change.
+ *
+ * `middleware.ts` is the only place route access is enforced, and it only runs on
+ * document requests. Client side navigations never reach the edge, so a user who is
+ * already inside a module keeps viewing it after an admin removes their role: the
+ * drawer recomputes from `user.roles` and hides the module, the page does not.
+ *
+ * A hard refresh does not recover either, because the middleware authorises from the
+ * roles inside the access token cookie, and that cookie is only replaced later, once
+ * an API call returns a user version mismatch.
+ */
+const useModuleAccessGuard = (): void => {
+  const router = useRouter();
+
+  const { isAuthenticated, user } = useAuth();
+
+  useEffect(() => {
+    const roles = user?.roles;
+
+    if (!isAuthenticated || !roles) return;
+
+    // `asPath` holds the public url, `pathname` holds the rewritten page path
+    const currentPath = router.asPath.split(/[?#]/)[0];
+
+    if (isModuleRouteRestricted(currentPath, roles)) {
+      void router.replace(ROUTES.DASHBOARD.BASE);
+    }
+  }, [isAuthenticated, user?.roles, router]);
+};
+
+export default useModuleAccessGuard;

--- a/frontend/src/community/common/hooks/useModuleAccessGuard.ts
+++ b/frontend/src/community/common/hooks/useModuleAccessGuard.ts
@@ -5,18 +5,6 @@ import { useAuth } from "~community/auth/providers/AuthProvider";
 import ROUTES from "~community/common/constants/routes";
 import { isModuleRouteRestricted } from "~community/common/utils/commonUtil";
 
-/**
- * Re-checks module access on the client whenever the user's roles change.
- *
- * `middleware.ts` is the only place route access is enforced, and it only runs on
- * document requests. Client side navigations never reach the edge, so a user who is
- * already inside a module keeps viewing it after an admin removes their role: the
- * drawer recomputes from `user.roles` and hides the module, the page does not.
- *
- * A hard refresh does not recover either, because the middleware authorises from the
- * roles inside the access token cookie, and that cookie is only replaced later, once
- * an API call returns a user version mismatch.
- */
 const useModuleAccessGuard = (): void => {
   const router = useRouter();
 
@@ -27,7 +15,6 @@ const useModuleAccessGuard = (): void => {
 
     if (!isAuthenticated || !roles) return;
 
-    // `asPath` holds the public url, `pathname` holds the rewritten page path
     const currentPath = router.asPath.split(/[?#]/)[0];
 
     if (isModuleRouteRestricted(currentPath, roles)) {

--- a/frontend/src/community/common/providers/TanStackProvider.tsx
+++ b/frontend/src/community/common/providers/TanStackProvider.tsx
@@ -34,7 +34,13 @@ const TanStackProvider = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => {
     const handleTokenRefresh = async () => {
-      await getNewAccessToken();
+      const refreshedAccessToken = await getNewAccessToken();
+
+      if (!refreshedAccessToken) {
+        await signOut();
+        return;
+      }
+
       await checkAuth();
       queryClient.invalidateQueries();
     };

--- a/frontend/src/community/common/utils/__test__/isModuleRouteRestricted.test.ts
+++ b/frontend/src/community/common/utils/__test__/isModuleRouteRestricted.test.ts
@@ -1,0 +1,160 @@
+/**
+ * `commonUtil` pulls in `next/server`, which needs the node environment
+ * @jest-environment node
+ */
+import ROUTES from "~community/common/constants/routes";
+import {
+  AdminTypes,
+  EmployeeTypes,
+  ManagerTypes,
+  ROLE_SUPER_ADMIN,
+  RepresentativeTypes
+} from "~community/common/types/AuthTypes";
+import { isModuleRouteRestricted } from "~community/common/utils/commonUtil";
+
+// Roles an employee keeps regardless of their module roles
+const baseRoles: string[] = [
+  EmployeeTypes.PEOPLE_EMPLOYEE,
+  EmployeeTypes.LEAVE_EMPLOYEE,
+  EmployeeTypes.ATTENDANCE_EMPLOYEE
+];
+
+describe("isModuleRouteRestricted", () => {
+  describe("CRM downgraded to none", () => {
+    it("restricts every CRM route", () => {
+      expect(isModuleRouteRestricted(ROUTES.CRM.BASE, baseRoles)).toBe(true);
+      expect(isModuleRouteRestricted(ROUTES.CRM.CONTACTS, baseRoles)).toBe(
+        true
+      );
+      expect(isModuleRouteRestricted(ROUTES.CRM.COMPANIES, baseRoles)).toBe(
+        true
+      );
+      expect(isModuleRouteRestricted(ROUTES.CRM.DEALS, baseRoles)).toBe(true);
+      expect(isModuleRouteRestricted(ROUTES.CRM.TASKS, baseRoles)).toBe(true);
+      expect(isModuleRouteRestricted("/crm/deals/123", baseRoles)).toBe(true);
+    });
+
+    it("restricts CRM for a super admin without a CRM role, matching the middleware", () => {
+      expect(
+        isModuleRouteRestricted(ROUTES.CRM.CONTACTS, [
+          ...baseRoles,
+          ROLE_SUPER_ADMIN
+        ])
+      ).toBe(true);
+    });
+
+    it("leaves the user's remaining modules alone", () => {
+      expect(isModuleRouteRestricted(ROUTES.DASHBOARD.BASE, baseRoles)).toBe(
+        false
+      );
+      expect(isModuleRouteRestricted(ROUTES.LEAVE.MY_REQUESTS, baseRoles)).toBe(
+        false
+      );
+      expect(
+        isModuleRouteRestricted(ROUTES.TIMESHEET.MY_TIMESHEET, baseRoles)
+      ).toBe(false);
+      expect(isModuleRouteRestricted(ROUTES.PEOPLE.DIRECTORY, baseRoles)).toBe(
+        false
+      );
+      expect(isModuleRouteRestricted(ROUTES.SETTINGS.BASE, baseRoles)).toBe(
+        false
+      );
+      expect(isModuleRouteRestricted(ROUTES.NOTIFICATIONS, baseRoles)).toBe(
+        false
+      );
+    });
+  });
+
+  describe("CRM granted", () => {
+    const crmRoles = [
+      ...baseRoles,
+      RepresentativeTypes.CRM_SALES_REPRESENTATIVE
+    ];
+
+    it("allows every CRM route", () => {
+      expect(isModuleRouteRestricted(ROUTES.CRM.BASE, crmRoles)).toBe(false);
+      expect(isModuleRouteRestricted(ROUTES.CRM.DEALS, crmRoles)).toBe(false);
+      expect(isModuleRouteRestricted("/crm/deals/123", crmRoles)).toBe(false);
+    });
+
+    it("allows CRM for the higher CRM roles, which inherit the representative role", () => {
+      expect(
+        isModuleRouteRestricted(ROUTES.CRM.DEALS, [
+          ...crmRoles,
+          ManagerTypes.CRM_SALES_MANAGER
+        ])
+      ).toBe(false);
+      expect(
+        isModuleRouteRestricted(ROUTES.CRM.DEALS, [
+          ...crmRoles,
+          AdminTypes.CRM_ADMIN
+        ])
+      ).toBe(false);
+    });
+  });
+
+  describe("the other module gates", () => {
+    it("restricts invoice without the invoice manager role", () => {
+      expect(isModuleRouteRestricted(ROUTES.INVOICE.BASE, baseRoles)).toBe(
+        true
+      );
+      expect(
+        isModuleRouteRestricted(ROUTES.INVOICE.ALL_INVOICES, [
+          ...baseRoles,
+          ManagerTypes.INVOICE_MANAGER
+        ])
+      ).toBe(false);
+    });
+
+    it("restricts projects without the pm employee role", () => {
+      expect(isModuleRouteRestricted(ROUTES.PROJECTS.BASE, baseRoles)).toBe(
+        true
+      );
+      expect(isModuleRouteRestricted(ROUTES.PROJECTS.GUESTS, baseRoles)).toBe(
+        true
+      );
+      expect(
+        isModuleRouteRestricted(ROUTES.PROJECTS.BASE, [
+          ...baseRoles,
+          EmployeeTypes.PM_EMPLOYEE
+        ])
+      ).toBe(false);
+    });
+
+    it("restricts leave and timesheet only when the base role is gone", () => {
+      const noLeaveOrAttendance = [EmployeeTypes.PEOPLE_EMPLOYEE];
+
+      expect(
+        isModuleRouteRestricted(ROUTES.LEAVE.MY_REQUESTS, noLeaveOrAttendance)
+      ).toBe(true);
+      expect(
+        isModuleRouteRestricted(
+          ROUTES.TIMESHEET.MY_TIMESHEET,
+          noLeaveOrAttendance
+        )
+      ).toBe(true);
+      expect(isModuleRouteRestricted(ROUTES.LEAVE.MY_REQUESTS, baseRoles)).toBe(
+        false
+      );
+    });
+  });
+
+  describe("routes outside the module gates", () => {
+    it("never restricts them, whatever the roles", () => {
+      [
+        ROUTES.AUTH.SIGNIN,
+        ROUTES.AUTH.UNAUTHORIZED,
+        ROUTES.AUTH.RESET_PASSWORD,
+        ROUTES.DASHBOARD.BASE,
+        ROUTES.CONFIGURATIONS.BASE,
+        ROUTES.PEOPLE.DIRECTORY,
+        ROUTES.SIGN.INBOX,
+        ROUTES.NOTIFICATIONS,
+        ROUTES.SETTINGS.BASE
+      ].forEach((route) => {
+        expect(isModuleRouteRestricted(route, [])).toBe(false);
+        expect(isModuleRouteRestricted(route, baseRoles)).toBe(false);
+      });
+    });
+  });
+});

--- a/frontend/src/community/common/utils/commonUtil.ts
+++ b/frontend/src/community/common/utils/commonUtil.ts
@@ -22,7 +22,7 @@ import { JobFamilies } from "~community/people/types/JobRolesTypes";
 import { getShortDayName } from "~community/people/utils/holidayUtils/commonUtils";
 
 import { appModes } from "../constants/configs";
-import ROUTES from "../constants/routes";
+import ROUTES, { moduleGuardedRoutes } from "../constants/routes";
 
 export const getBlinkClass = (shouldBlink: boolean): string =>
   shouldBlink ? "animate-pulse" : "";
@@ -520,6 +520,16 @@ export const checkRestrictedRoutesAndRedirect = (
   }
   return null;
 };
+
+export const isModuleRouteRestricted = (
+  pathname: string,
+  roles: string[]
+): boolean =>
+  moduleGuardedRoutes.some(
+    ({ routes, requiredRole }) =>
+      routes.some((url) => pathname.startsWith(url)) &&
+      !roles.includes(requiredRole)
+  );
 
 export const getLabelForReadOnlyChip = (
   isBelow1024?: boolean,

--- a/frontend/src/fallback/common/api/utils/ApiEndpoints.ts
+++ b/frontend/src/fallback/common/api/utils/ApiEndpoints.ts
@@ -1,1 +1,6 @@
-export const authenticationEndpoints = {};
+import { ApiVersions } from "~community/common/constants/configs";
+
+export const authenticationEndpoints = {
+  REFRESH_TOKEN: `${ApiVersions.V1}/auth/session/refresh-token`,
+  SIGNOUT: `${ApiVersions.V1}/auth/session/sign-out`
+};


### PR DESCRIPTION
## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/[id]) 

### Summary

<html>
<body>
<!--StartFragment--><html><head></head><body><p>Here's a ready-to-paste PR description covering the full branch:</p>
<hr>
<h2>Summary</h2>
<p>Fixes <strong>CRM-559</strong>: when an admin revokes a user's module access (e.g. sets CRM to <strong>None</strong>), the user could keep viewing that module's pages (<code>/crm</code>) until their access token expired (~1 hour) or they manually signed out. This PR makes revocation take effect promptly by repairing the token-refresh path and adding a client-side module access guard.</p>
<h2>Root cause</h2>
<p>Access revocation relies on a 4-step chain. Step 3 was broken, which silently disabled step 4:</p>
<ol>
<li><strong>Backend</strong> invalidates the stale token → next API call returns <code>USER_VERSION_MISMATCH</code>. ✅</li>
<li><strong>Frontend interceptor</strong> catches the mismatch and requests a token refresh. ✅</li>
<li><strong>Token refresh had no endpoint URL.</strong> ❌ — The refresh call reads <code>authenticationEndpoints.REFRESH_TOKEN</code>, imported from <code>~enterprise/...</code>. In community builds the enterprise submodule isn't present, so the import falls back to <code>src/fallback/common/api/utils/ApiEndpoints.ts</code>, which was literally <code>export const authenticationEndpoints = {}</code>. <code>REFRESH_TOKEN</code> was <code>undefined</code>, so <strong>every refresh in community builds failed</strong>.</li>
<li><strong>The failure was swallowed.</strong> <code>getNewAccessToken()</code> returned <code>null</code>, but the caller ignored it and called <code>checkAuth()</code>, which re-read the <strong>same stale cookie</strong> and restored the <strong>old roles</strong>. Since roles never changed, the client had no signal to re-evaluate route access, so the user stayed on the module.</li>
</ol>
<p>Additionally, route access was only enforced by <code>middleware.ts</code>, which runs on document requests. Client-side navigations never reach the edge, so nothing re-checked access while the user stayed inside the app.</p>
<h2>Fix</h2>
<p><strong>1. Restore the community auth endpoints</strong> (<code>fallback/.../ApiEndpoints.ts</code>)
Populated the fallback with the session (cookie) based endpoints matching <code>CREDENTIAL_SIGN_IN</code>:</p>
<ul>
<li><code>REFRESH_TOKEN: /v1/auth/session/refresh-token</code></li>
<li><code>SIGNOUT: /v1/auth/session/sign-out</code></li>
</ul>
<p><strong>2. Fail safe on a failed refresh</strong> (<code>TanStackProvider.tsx</code>)
If the refresh cannot mint a new token (<code>getNewAccessToken()</code> returns <code>null</code>), the session is ended instead of silently retaining stale permissions:</p>
<pre><code class="language-ts">const refreshedAccessToken = await getNewAccessToken();
if (!refreshedAccessToken) { await signOut(); return; }
</code></pre>
<p><strong>3. Client-side module access guard</strong> (<code>useModuleAccessGuard</code>, <code>moduleGuardedRoutes</code>, <code>isModuleRouteRestricted</code>)
A new hook, mounted in <code>BaseLayout</code>, re-checks module access whenever <code>user.roles</code> changes. If the user is on a route they no longer have the required role for, it redirects to the dashboard. The route→role table mirrors the gates <code>getDrawerRoutes</code> already applies (CRM, Invoice, Projects, Leave, Timesheet), so the guard is never stricter than the sidebar.</p>
<h3>Resulting behaviour</h3>

Refresh outcome | Result
-- | --
Succeeds (properly configured origin) | Roles update → guard redirects to dashboard
Fails (e.g. refresh token gone/expired) | User is signed out


<p>Either way, the user stops viewing a module they no longer have access to.</p>
<h2>Testing</h2>
<ul>
<li>Added <code>isModuleRouteRestricted.test.ts</code> (9 cases): CRM downgrade, higher CRM roles inheriting the representative role, super-admin without a CRM role, and the other four module gates. All passing.</li>
<li>Verified live against the running backend: after downgrading a user's CRM role, <code>POST /v1/auth/session/refresh-token</code> returns <code>200</code> with a token whose <code>roles</code> no longer include CRM.</li>
<li>Verified the role model is cumulative (an admin/manager token also carries the base role), so the guard cannot wrongly redirect a legitimate admin/manager.</li>
</ul>
<h2>Risk / breaking changes</h2>
<ul>
<li><strong>No change to any working flow.</strong> The refresh success path is unchanged; new behaviour only occurs on the refresh <em>failure</em> path (which was already broken), where the app now fails safe (sign out) instead of failing open (retain revoked access).</li>
<li><strong>Enterprise unaffected by the endpoints change</strong> — <code>~enterprise/*</code> resolves to the enterprise sources first; the fallback is used only in community builds. The guard and sign-out handler run in both community and enterprise, and mirror existing drawer gates.</li>
</ul>
<h2>Ticket</h2>
<p>CRM-559</p>
<hr>
<p>Want me to tailor the tone (shorter/more concise), add a screenshots/GIF section, or save this to a file?</p></body></html><!--EndFragment-->
</body>
</html>

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
