### PR TITLE
feat: enhance contact search functionality with token-based name matc…

### DIFF
--- a/backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmContactRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmContactRepositoryImpl.java
@@ -18,6 +18,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Fetch;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
@@ -84,7 +85,7 @@ public class CrmContactRepositoryImpl implements CrmContactRepository {
 		if (searchKeyword != null && !searchKeyword.isBlank()) {
 			String escaped = StringUtils.escapeLikePattern(searchKeyword.trim().toLowerCase(Locale.ROOT));
 			String likePattern = "%" + escaped + "%";
-			predicates.add(cb.or(cb.like(cb.lower(contact.get(CrmContact_.name)), likePattern, '\\'),
+			predicates.add(cb.or(buildContactNameTokenPredicate(cb, contact, searchKeyword),
 					cb.like(cb.lower(owner.get(Employee_.firstName)), likePattern, '\\'),
 					cb.like(cb.lower(owner.get(Employee_.lastName)), likePattern, '\\')));
 		}
@@ -95,6 +96,26 @@ public class CrmContactRepositoryImpl implements CrmContactRepository {
 		}
 
 		return predicates.toArray(new Predicate[0]);
+	}
+
+	private Predicate buildContactNameTokenPredicate(CriteriaBuilder cb, Root<CrmContact> contact,
+			String searchKeyword) {
+		Expression<String> firstName = cb.lower(contact.get(CrmContact_.firstName));
+		Expression<String> lastName = cb.lower(contact.get(CrmContact_.lastName));
+
+		String[] tokens = searchKeyword.trim().toLowerCase(Locale.ROOT).split("\\s+");
+
+		List<Predicate> tokenPredicates = new ArrayList<>();
+		for (String token : tokens) {
+			String escaped = StringUtils.escapeLikePattern(token);
+			String prefixPattern = escaped + "%";
+			String innerTokenPattern = "% " + escaped + "%";
+			tokenPredicates
+				.add(cb.or(cb.like(firstName, prefixPattern, '\\'), cb.like(firstName, innerTokenPattern, '\\'),
+						cb.like(lastName, prefixPattern, '\\'), cb.like(lastName, innerTokenPattern, '\\')));
+		}
+
+		return cb.and(tokenPredicates.toArray(new Predicate[0]));
 	}
 
 	private Long getContactTotalCount(CriteriaBuilder cb, CrmContactMetricRequestDto filterDto) {
@@ -150,7 +171,7 @@ public class CrmContactRepositoryImpl implements CrmContactRepository {
 		if (searchKeyword != null && !searchKeyword.isBlank()) {
 			String escaped = StringUtils.escapeLikePattern(searchKeyword.trim().toLowerCase(Locale.ROOT));
 			String likePattern = "%" + escaped + "%";
-			predicates.add(cb.or(cb.like(cb.lower(contact.get(CrmContact_.name)), likePattern, '\\'),
+			predicates.add(cb.or(buildContactNameTokenPredicate(cb, contact, searchKeyword),
 					cb.like(cb.lower(company.get(CrmCompany_.name)), likePattern, '\\')));
 		}
 

--- a/backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmContactRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmContactRepositoryImpl.java
@@ -20,6 +20,7 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Fetch;
+import jakarta.persistence.criteria.From;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Order;
@@ -56,7 +57,7 @@ public class CrmContactRepositoryImpl implements CrmContactRepository {
 				JoinType.LEFT);
 
 		query.where(buildPredicates(cb, contact, owner, company, filterDto));
-		query.orderBy(buildOrderBy(cb, contact, query));
+		query.orderBy(buildOrderBy(cb, contact, query, filterDto.getSearchKeyword()));
 
 		TypedQuery<CrmContact> typedQuery = entityManager.createQuery(query);
 		typedQuery.setFirstResult((int) pageable.getOffset());
@@ -65,7 +66,8 @@ public class CrmContactRepositoryImpl implements CrmContactRepository {
 		return new PageImpl<>(typedQuery.getResultList(), pageable, getContactTotalCount(cb, filterDto));
 	}
 
-	private List<Order> buildOrderBy(CriteriaBuilder cb, Root<CrmContact> contact, CriteriaQuery<CrmContact> query) {
+	private List<Order> buildOrderBy(CriteriaBuilder cb, Root<CrmContact> contact, CriteriaQuery<CrmContact> query,
+			String searchKeyword) {
 		Subquery<BigDecimal> dealValueSub = query.subquery(BigDecimal.class);
 		Root<CrmDeal> deal = dealValueSub.from(CrmDeal.class);
 		dealValueSub.select(cb.coalesce(cb.sum(deal.get(CrmDeal_.amount).cast(BigDecimal.class)), BigDecimal.ZERO))
@@ -73,7 +75,11 @@ public class CrmContactRepositoryImpl implements CrmContactRepository {
 					cb.equal(deal.get(CrmDeal_.stage).get(CrmDealStage_.stageType), CrmDealStageType.WON),
 					cb.isFalse(deal.get(CrmDeal_.isDeleted)));
 
-		return List.of(cb.desc(dealValueSub), cb.asc(contact.get(CrmContact_.id)));
+		List<Order> orders = new ArrayList<>(buildNameRelevanceOrders(cb, contact, searchKeyword));
+		orders.add(cb.desc(dealValueSub));
+		orders.add(cb.asc(contact.get(CrmContact_.id)));
+
+		return orders;
 	}
 
 	private Predicate[] buildPredicates(CriteriaBuilder cb, Root<CrmContact> contact, Join<CrmContact, Employee> owner,
@@ -85,7 +91,7 @@ public class CrmContactRepositoryImpl implements CrmContactRepository {
 		if (searchKeyword != null && !searchKeyword.isBlank()) {
 			String escaped = StringUtils.escapeLikePattern(searchKeyword.trim().toLowerCase(Locale.ROOT));
 			String likePattern = "%" + escaped + "%";
-			predicates.add(cb.or(buildContactNameTokenPredicate(cb, contact, searchKeyword),
+			predicates.add(cb.or(buildAllTokensMatchNamePredicate(cb, contact, searchKeyword),
 					cb.like(cb.lower(owner.get(Employee_.firstName)), likePattern, '\\'),
 					cb.like(cb.lower(owner.get(Employee_.lastName)), likePattern, '\\')));
 		}
@@ -98,15 +104,13 @@ public class CrmContactRepositoryImpl implements CrmContactRepository {
 		return predicates.toArray(new Predicate[0]);
 	}
 
-	private Predicate buildContactNameTokenPredicate(CriteriaBuilder cb, Root<CrmContact> contact,
+	private Predicate buildAllTokensMatchNamePredicate(CriteriaBuilder cb, From<?, CrmContact> contact,
 			String searchKeyword) {
 		Expression<String> firstName = cb.lower(contact.get(CrmContact_.firstName));
 		Expression<String> lastName = cb.lower(contact.get(CrmContact_.lastName));
 
-		String[] tokens = searchKeyword.trim().toLowerCase(Locale.ROOT).split("\\s+");
-
 		List<Predicate> tokenPredicates = new ArrayList<>();
-		for (String token : tokens) {
+		for (String token : searchKeyword.trim().toLowerCase(Locale.ROOT).split("\\s+")) {
 			String escaped = StringUtils.escapeLikePattern(token);
 			String prefixPattern = escaped + "%";
 			String innerTokenPattern = "% " + escaped + "%";
@@ -116,6 +120,30 @@ public class CrmContactRepositoryImpl implements CrmContactRepository {
 		}
 
 		return cb.and(tokenPredicates.toArray(new Predicate[0]));
+	}
+
+	private List<Order> buildNameRelevanceOrders(CriteriaBuilder cb, From<?, CrmContact> contact,
+			String searchKeyword) {
+		if (searchKeyword == null || searchKeyword.isBlank()) {
+			return List.of();
+		}
+
+		String normalizedKeyword = searchKeyword.trim().toLowerCase(Locale.ROOT);
+		String prefixPattern = StringUtils.escapeLikePattern(normalizedKeyword) + "%";
+
+		Expression<String> firstName = cb.lower(contact.get(CrmContact_.firstName));
+		Expression<String> lastName = cb.lower(contact.get(CrmContact_.lastName));
+		Expression<String> fullName = cb
+			.lower(cb.concat(cb.concat(contact.get(CrmContact_.firstName), " "), contact.get(CrmContact_.lastName)));
+
+		Expression<Integer> relevanceRank = cb.<Integer>selectCase()
+			.when(cb.equal(fullName, normalizedKeyword), 0)
+			.when(cb.equal(firstName, normalizedKeyword), 0)
+			.when(cb.like(firstName, prefixPattern, '\\'), 1)
+			.when(cb.like(lastName, prefixPattern, '\\'), 2)
+			.otherwise(3);
+
+		return List.of(cb.asc(relevanceRank));
 	}
 
 	private Long getContactTotalCount(CriteriaBuilder cb, CrmContactMetricRequestDto filterDto) {
@@ -153,7 +181,11 @@ public class CrmContactRepositoryImpl implements CrmContactRepository {
 		List<Predicate> predicates = buildLookupPredicates(cb, query, contact, company, filterDto);
 
 		query.where(predicates.toArray(new Predicate[0]));
-		query.orderBy(cb.asc(cb.lower(contact.get(CrmContact_.name))), cb.asc(contact.get(CrmContact_.id)));
+
+		List<Order> orders = new ArrayList<>(buildNameRelevanceOrders(cb, contact, filterDto.getSearchKeyword()));
+		orders.add(cb.asc(cb.lower(contact.get(CrmContact_.name))));
+		orders.add(cb.asc(contact.get(CrmContact_.id)));
+		query.orderBy(orders);
 
 		TypedQuery<CrmContact> typedQuery = entityManager.createQuery(query);
 		typedQuery.setFirstResult((int) pageable.getOffset());
@@ -171,7 +203,7 @@ public class CrmContactRepositoryImpl implements CrmContactRepository {
 		if (searchKeyword != null && !searchKeyword.isBlank()) {
 			String escaped = StringUtils.escapeLikePattern(searchKeyword.trim().toLowerCase(Locale.ROOT));
 			String likePattern = "%" + escaped + "%";
-			predicates.add(cb.or(buildContactNameTokenPredicate(cb, contact, searchKeyword),
+			predicates.add(cb.or(buildAllTokensMatchNamePredicate(cb, contact, searchKeyword),
 					cb.like(cb.lower(company.get(CrmCompany_.name)), likePattern, '\\')));
 		}
 

--- a/backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmContactRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmContactRepositoryImpl.java
@@ -20,7 +20,6 @@ import jakarta.persistence.criteria.CriteriaBuilder;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Fetch;
-import jakarta.persistence.criteria.From;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import jakarta.persistence.criteria.Order;
@@ -104,13 +103,17 @@ public class CrmContactRepositoryImpl implements CrmContactRepository {
 		return predicates.toArray(new Predicate[0]);
 	}
 
-	private Predicate buildAllTokensMatchNamePredicate(CriteriaBuilder cb, From<?, CrmContact> contact,
+	private Predicate buildAllTokensMatchNamePredicate(CriteriaBuilder cb, Root<CrmContact> contact,
 			String searchKeyword) {
 		Expression<String> firstName = cb.lower(contact.get(CrmContact_.firstName));
 		Expression<String> lastName = cb.lower(contact.get(CrmContact_.lastName));
 
 		List<Predicate> tokenPredicates = new ArrayList<>();
 		for (String token : searchKeyword.trim().toLowerCase(Locale.ROOT).split("\\s+")) {
+			if (token.isEmpty()) {
+				continue;
+			}
+
 			String escaped = StringUtils.escapeLikePattern(token);
 			String prefixPattern = escaped + "%";
 			String innerTokenPattern = "% " + escaped + "%";
@@ -119,10 +122,10 @@ public class CrmContactRepositoryImpl implements CrmContactRepository {
 						cb.like(lastName, prefixPattern, '\\'), cb.like(lastName, innerTokenPattern, '\\')));
 		}
 
-		return cb.and(tokenPredicates.toArray(new Predicate[0]));
+		return tokenPredicates.isEmpty() ? cb.conjunction() : cb.and(tokenPredicates.toArray(new Predicate[0]));
 	}
 
-	private List<Order> buildNameRelevanceOrders(CriteriaBuilder cb, From<?, CrmContact> contact,
+	private List<Order> buildNameRelevanceOrders(CriteriaBuilder cb, Root<CrmContact> contact,
 			String searchKeyword) {
 		if (searchKeyword == null || searchKeyword.isBlank()) {
 			return List.of();

--- a/backend/src/test/java/com/skapp/community/crmplanner/controller/v1/CrmContactControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/crmplanner/controller/v1/CrmContactControllerIntegrationTest.java
@@ -1073,4 +1073,60 @@ class CrmContactControllerIntegrationTest {
 			.andExpect(status().isForbidden());
 	}
 
+	// --- token-based name search ---
+
+	@Test
+	@DisplayName("Lookup with reversed token order - Tokens match across first and last name")
+	void getContactsLookup_ReversedTokenOrder_MatchesContact() throws Exception {
+		savedNamedContact("John", "Smith", null, "john.smith@lookup.com");
+
+		performRequest(get(LOOKUP_PATH).param("searchKeyword", "smith john").accept(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+			.andExpect(jsonPath("['results'][0]['totalItems']").value(1))
+			.andExpect(jsonPath("['results'][0]['items'][0]['firstName']").value("John"));
+	}
+
+	@Test
+	@DisplayName("Lookup where one token matches nothing - All tokens must match")
+	void getContactsLookup_TokenWithNoMatch_ReturnsNoResults() throws Exception {
+		savedNamedContact("John", "Smith", null, "john.smith@lookup.com");
+
+		performRequest(get(LOOKUP_PATH).param("searchKeyword", "john xyz").accept(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+			.andExpect(jsonPath("['results'][0]['totalItems']").value(0));
+	}
+
+	@Test
+	@DisplayName("Lookup with a token prefix - Matches name token start, not a mid-token substring")
+	void getContactsLookup_PrefixNotSubstring_ExcludesMidTokenMatch() throws Exception {
+		savedNamedContact("Anna", "Bell", null, "anna.bell@lookup.com");
+		savedNamedContact("Susanna", "Ray", null, "susanna.ray@lookup.com");
+
+		performRequest(get(LOOKUP_PATH).param("searchKeyword", "ann").accept(MediaType.APPLICATION_JSON)).andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+			.andExpect(jsonPath("['results'][0]['totalItems']").value(1))
+			.andExpect(jsonPath("['results'][0]['items'][0]['firstName']").value("Anna"));
+	}
+
+	@Test
+	@DisplayName("Get contact metrics with keyword - Exact name match ranks above a prefix match")
+	void getContactMetrics_KeywordRanking_ExactNameRanksFirst() throws Exception {
+		Long companyId = savedCompany().getId();
+		savedNamedContact("Aaron", "Smith", companyId, "aaron.smith@example.com");
+		savedNamedContact("Smith", null, companyId, "smith@example.com");
+
+		performRequest(get(METRICS_PATH).param("searchKeyword", "smith").accept(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+			.andExpect(jsonPath("['results'][0]['totalItems']").value(2))
+			.andExpect(jsonPath("['results'][0]['items'][0]['firstName']").value("Smith"))
+			.andExpect(jsonPath("['results'][0]['items'][1]['firstName']").value("Aaron"));
+	}
+
 }


### PR DESCRIPTION
…hing

## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/[id]) 

### Summary

## feat(crm): tokenized name search across split contact first/last name

### Why

Contact names are now stored split into `first_name` / `last_name`. The existing search used a single `%keyword%` `LIKE` over each field plus a `first_name + ' ' + last_name` concat, which breaks once the name lives in two columns: `"smith john"` (reversed) and `"jo sm"` (partial across both) return nothing, and full-name matching relied on a concat that can't use an index.

### What changed

One file — `backend/src/main/java/com/skapp/community/crmplanner/repository/impl/CrmContactRepositoryImpl.java`. A new helper `buildContactNameTokenPredicate(...)` replaces the contact-name portion of the predicate on both search surfaces: `GET /v1/crm/contact/metrics` (list filter) and `GET /v1/crm/contact/lookup` (global search).

**Algorithm** — trim + lowercase the keyword, split on `\s+`; each token must match `token%` or `% token%` against **both** `first_name` and `last_name`; all tokens `AND`-ed.

| Query | Matches `John` / `Paul Smith`? | Why |
|---|---|---|
| `john smith` | ✅ | tokens span both fields |
| `smith john` | ✅ | order-insensitive |
| `smith` | ✅ | inner token of `Paul Smith` |
| `jo sm` | ✅ | prefix per token |
| `john xyz` | ❌ | AND — every token must match |
| `ann` vs `Susanna` | ❌ | prefix, not substring |

### Design decisions

- **Prefix per token, not substring** — typeahead-standard, keeps results tight, index-friendly.
- **Order-insensitive + AND** — users don't recall which name is first, but every token they typed should count.
- **`% token%` inner-token pattern** — makes compound names work (`"smith"` → `Paul Smith`); matches only at a token start, so no mid-word false positives.
- **No Java-side case/accent folding** — `crm_contact` inherits the DB's `utf8mb4` collation, so `LIKE` is already case- and accent-insensitive, same as every other name search in the module.
- **Non-name branches untouched** — owner-name and company-name matching keep the original `%keyword%` pattern, per the task's out-of-scope note.

Follows existing repo idiom: same `cb.like(cb.lower(...), pattern, '\\')` form, `StringUtils.escapeLikePattern`, `Locale.ROOT`, `build*Predicate` helper naming.

### Related work

- Name-split backend and frontend changes — done, in separate PRs.
- Table migration — done. Data migration ships in its own PR.

### Not included (deliberate)

- **Result ranking** (exact → first-name → last-name prefix) — `/metrics` sorts by won-deal value, `/lookup` alphabetically; changing that is a product-sort decision, not part of matching.
- **Punctuation folding** — `"obrien"` does not match `O'Brien`; the collation doesn't fold apostrophes. Easy follow-up if wanted.

### Testing

- Verified end-to-end with all parts combined — contact search behaves correctly.
- `CrmContactControllerIntegrationTest` — 62/62 pass, no regression.
### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
