### PR TITLE
fix: end previous position one day before new position's start date

### DIFF
--- a/frontend/src/community/common/utils/dateTimeUtils.ts
+++ b/frontend/src/community/common/utils/dateTimeUtils.ts
@@ -28,6 +28,12 @@ export const getDateFromTimeStamp = (timestamp: string): string => {
   return timestamp.split("T")[0];
 };
 
+export const getPreviousDayFormatted = (timestamp: string): string => {
+  return DateTime.fromISO(getDateFromTimeStamp(timestamp))
+    .minus({ days: 1 })
+    .toFormat(LONG_DATE_TIME_FORMAT);
+};
+
 export const getOrdinalIndicator = (day: number) => {
   if (day === 1 || day === 21 || day === 31) {
     return "st";

--- a/frontend/src/community/people/components/organisms/AddNewResourceFlow/EmploymentDetailsSection/CareerProgressionDetailsSection.tsx
+++ b/frontend/src/community/people/components/organisms/AddNewResourceFlow/EmploymentDetailsSection/CareerProgressionDetailsSection.tsx
@@ -28,7 +28,8 @@ import {
 } from "~community/common/utils/commonUtil";
 import {
   convertDateToFormat,
-  getDateFromTimeStamp
+  getDateFromTimeStamp,
+  getPreviousDayFormatted
 } from "~community/common/utils/dateTimeUtils";
 import { useGetPreprocessedRoles } from "~community/people/api/PeopleApi";
 import { JobFamilyActionModalEnums } from "~community/people/enums/JobFamilyEnums";
@@ -343,10 +344,7 @@ const CareerProgressionDetailsSection = ({
           positions[index] = {
             ...position,
             currentPosition: false,
-            endDate: convertDateToFormat(
-              DateTime.fromMillis(newStartDate).minus({ days: 1 }).toJSDate(),
-              LONG_DATE_TIME_FORMAT
-            )
+            endDate: getPreviousDayFormatted(startDate)
           };
         }
       });

--- a/frontend/src/community/people/components/organisms/AddNewResourceFlow/EmploymentDetailsSection/CareerProgressionDetailsSection.tsx
+++ b/frontend/src/community/people/components/organisms/AddNewResourceFlow/EmploymentDetailsSection/CareerProgressionDetailsSection.tsx
@@ -344,7 +344,7 @@ const CareerProgressionDetailsSection = ({
             ...position,
             currentPosition: false,
             endDate: convertDateToFormat(
-              new Date(newStartDate),
+              DateTime.fromMillis(newStartDate).minus({ days: 1 }).toJSDate(),
               LONG_DATE_TIME_FORMAT
             )
           };

--- a/frontend/src/community/people/components/organisms/EmploymentFormSection/SubSections/CareerProgressDetailsSection.tsx
+++ b/frontend/src/community/people/components/organisms/EmploymentFormSection/SubSections/CareerProgressDetailsSection.tsx
@@ -12,7 +12,8 @@ import { useTranslator } from "~community/common/hooks/useTranslator";
 import { IconName } from "~community/common/types/IconTypes";
 import {
   convertDateToFormat,
-  getDateFromTimeStamp
+  getDateFromTimeStamp,
+  getPreviousDayFormatted
 } from "~community/common/utils/dateTimeUtils";
 import PeopleFormTable from "~community/people/components/molecules/PeopleFormTable/PeopleFormTable";
 import { JobFamilyActionModalEnums } from "~community/people/enums/JobFamilyEnums";
@@ -120,10 +121,7 @@ const CareerProgressDetailsSection = ({
           positions[index] = {
             ...position,
             isCurrentEmployment: false,
-            endDate: convertDateToFormat(
-              DateTime.fromMillis(newStartDate).minus({ days: 1 }).toJSDate(),
-              LONG_DATE_TIME_FORMAT
-            )
+            endDate: getPreviousDayFormatted(startDate ?? "")
           };
         }
       });

--- a/frontend/src/community/people/components/organisms/EmploymentFormSection/SubSections/CareerProgressDetailsSection.tsx
+++ b/frontend/src/community/people/components/organisms/EmploymentFormSection/SubSections/CareerProgressDetailsSection.tsx
@@ -121,7 +121,7 @@ const CareerProgressDetailsSection = ({
           positions[index] = {
             ...position,
             isCurrentEmployment: false,
-            endDate: getPreviousDayFormatted(startDate ?? "")
+            endDate: getPreviousDayFormatted(startDate)
           };
         }
       });

--- a/frontend/src/community/people/components/organisms/EmploymentFormSection/SubSections/CareerProgressDetailsSection.tsx
+++ b/frontend/src/community/people/components/organisms/EmploymentFormSection/SubSections/CareerProgressDetailsSection.tsx
@@ -121,7 +121,7 @@ const CareerProgressDetailsSection = ({
             ...position,
             isCurrentEmployment: false,
             endDate: convertDateToFormat(
-              new Date(newStartDate),
+              DateTime.fromMillis(newStartDate).minus({ days: 1 }).toJSDate(),
               LONG_DATE_TIME_FORMAT
             )
           };


### PR DESCRIPTION
Bug: When adding a new position for an employee without manually ending the previous one, and marking the new position as current, the system auto-ends the previous position but sets its end date to the same date as the new position's start date, causing a one-day overlap between the two positions.

Root Cause: Frontend logic in CareerProgressDetailsSection.tsx (Employment tab) and CareerProgressionDetailsSection.tsx (Add New Resource wizard) assigns the new position's start-date timestamp directly to the previous position's endDate with no -1 day adjustment.

Fix: Previous position's endDate now computed as newStartDate - 1 day (via Luxon .minus({ days: 1 })) instead of newStartDate directly, in both CareerProgressDetailsSection.tsx and CareerProgressionDetailsSection.tsx.