### PR TITLE
fix: restore pending filter when navigating back from timesheet full list view

### DIFF
--- a/frontend/src/community/attendance/hooks/useTimesheetRequestFilterState.ts
+++ b/frontend/src/community/attendance/hooks/useTimesheetRequestFilterState.ts
@@ -18,7 +18,8 @@ export const useTimesheetRequestFilterState = (
     timesheetRequestSelectedDates,
     setTimesheetRequestsFilters,
     setTimesheetRequestSelectedDates,
-    resetTimesheetRequestParams
+    resetTimesheetRequestParams,
+    restoreTimesheetRequestParams
   } = useAttendanceStore();
 
   const filterValues = isManager
@@ -39,6 +40,9 @@ export const useTimesheetRequestFilterState = (
   const resetParams = isManager
     ? resetTimesheetRequestParams
     : resetEmployeeTimesheetRequestParams;
+  const cleanupParams = isManager
+    ? restoreTimesheetRequestParams
+    : resetEmployeeTimesheetRequestParams;
 
   const [appliedStartDate, appliedEndDate] = appliedDates;
   const filterCount =
@@ -47,10 +51,10 @@ export const useTimesheetRequestFilterState = (
   useEffect(() => {
     if (!shouldRegisterCleanup) return;
     return () => {
-      resetParams();
+      cleanupParams();
       setDates(["", ""]);
     };
-  }, [shouldRegisterCleanup, resetParams, setDates]);
+  }, [shouldRegisterCleanup, cleanupParams, setDates]);
 
   return {
     filterValues,

--- a/frontend/src/community/attendance/hooks/useTimesheetRequestFilterState.ts
+++ b/frontend/src/community/attendance/hooks/useTimesheetRequestFilterState.ts
@@ -50,11 +50,12 @@ export const useTimesheetRequestFilterState = (
 
   useEffect(() => {
     if (!shouldRegisterCleanup) return;
+    resetParams();
     return () => {
       cleanupParams();
       setDates(["", ""]);
     };
-  }, [shouldRegisterCleanup, cleanupParams, setDates]);
+  }, [shouldRegisterCleanup, resetParams, cleanupParams, setDates]);
 
   return {
     filterValues,

--- a/frontend/src/community/attendance/store/slices/managerTimesheetFiltersSlice.ts
+++ b/frontend/src/community/attendance/store/slices/managerTimesheetFiltersSlice.ts
@@ -78,7 +78,7 @@ const managerTimesheetFiltersSlice = (
   restoreTimesheetRequestParams: () => {
     set((state) => ({
       timesheetRequestsFilters: {
-        status: [TimeSheetRequestStates.PENDING] as string[]
+        status: [] as string[]
       },
       timesheetRequestParams: {
         ...state.timesheetRequestParams,

--- a/frontend/src/community/attendance/store/slices/managerTimesheetFiltersSlice.ts
+++ b/frontend/src/community/attendance/store/slices/managerTimesheetFiltersSlice.ts
@@ -14,7 +14,7 @@ const managerTimesheetFiltersSlice = (
   set: SetType<ManagerTimesheetFiltersSliceTypes>
 ): ManagerTimesheetFiltersSliceTypes => ({
   timesheetRequestsFilters: {
-    status: []
+    status: [TimeSheetRequestStates.PENDING]
   },
   timesheetRequestSelectedDates: [],
   timesheetRequestParams: {
@@ -78,7 +78,7 @@ const managerTimesheetFiltersSlice = (
   restoreTimesheetRequestParams: () => {
     set((state) => ({
       timesheetRequestsFilters: {
-        status: [] as string[]
+        status: [TimeSheetRequestStates.PENDING] as string[]
       },
       timesheetRequestParams: {
         ...state.timesheetRequestParams,

--- a/frontend/src/community/attendance/store/slices/managerTimesheetFiltersSlice.ts
+++ b/frontend/src/community/attendance/store/slices/managerTimesheetFiltersSlice.ts
@@ -75,6 +75,19 @@ const managerTimesheetFiltersSlice = (
     }));
   },
 
+  restoreTimesheetRequestParams: () => {
+    set((state) => ({
+      timesheetRequestsFilters: {
+        status: [] as string[]
+      },
+      timesheetRequestParams: {
+        ...state.timesheetRequestParams,
+        status: TimeSheetRequestStates.PENDING,
+        page: 1
+      }
+    }));
+  },
+
   setTimesheetRequestSelectedDates: (value: string[]) => {
     set((state) => ({
       ...state,

--- a/frontend/src/community/attendance/store/slices/managerTimesheetFiltersSlice.ts
+++ b/frontend/src/community/attendance/store/slices/managerTimesheetFiltersSlice.ts
@@ -76,9 +76,9 @@ const managerTimesheetFiltersSlice = (
   },
 
   restoreTimesheetRequestParams: () => {
-    set((state) => ({
+    set((state): Partial<ManagerTimesheetFiltersSliceTypes> => ({
       timesheetRequestsFilters: {
-        status: [] as string[]
+        status: []
       },
       timesheetRequestParams: {
         ...state.timesheetRequestParams,

--- a/frontend/src/community/attendance/types/attendanceSliceTypes.ts
+++ b/frontend/src/community/attendance/types/attendanceSliceTypes.ts
@@ -25,6 +25,7 @@ export interface ManagerTimesheetFiltersSliceTypes
     | "timesheetRequestsFilterValues"
     | "setTimesheetRequestsFilters"
     | "resetTimesheetRequestParams"
+    | "restoreTimesheetRequestParams"
     | "setTimesheetRequestSelectedDates"
     | "setTimesheetRequestPagination"
     | "timesheetAnalyticsParams"

--- a/frontend/src/community/attendance/types/attendanceStoreTypes.ts
+++ b/frontend/src/community/attendance/types/attendanceStoreTypes.ts
@@ -18,6 +18,7 @@ interface actionsTypes {
     selectedFilters: Record<string, string[]>
   ) => void;
   resetTimesheetRequestParams: () => void;
+  restoreTimesheetRequestParams: () => void;
   setTimesheetRequestSelectedDates: (value: string[]) => void;
   setTimesheetRequestPagination: (page: number) => void;
   setTimesheetAnalyticsSelectedDates: (value: string[]) => void;


### PR DESCRIPTION
Bug: On the All Timesheets page, the "Request Waiting for Approval" table doesn't show the full/correct list of pending requests after navigating back from the "View Full List" page. Only a subset of pending requests appears, and a manual page reload is required to see the correct list again.

Root Cause: The pending-requests widget (ManagerTimesheetRequestTable on All Timesheets) and the "View Full List" page share the same timesheetRequestParams state in the manager timesheet filter slice. When the full-list page unmounts (i.e. the user navigates back), a cleanup effect in useTimesheetRequestFilterState.ts called resetTimesheetRequestParams(), which sets status: ""  the correct default for entering the full list (show all statuses), but wrong for the widget, which needs status: PENDING. As a result, on navigating back, the widget's query fetched the most recent requests of any status instead of pending-only, then filtered that already-limited result set for pending items client-side surfacing only whichever pending requests happened to be in that unfiltered batch.

Fix: Added a separate restoreTimesheetRequestParams action (in managerTimesheetFiltersSlice.ts) that resets status back to PENDING instead of "", and wired the unmount cleanup in useTimesheetRequestFilterState.ts to call it (via a new cleanupParams reference) instead of reusing resetTimesheetRequestParams, which remains unchanged for its original uses (entering the full list, and the filter popover's "Reset" button).