### PR TITLE
feat(crm): v2 task response types (stacked on #1732)

### DIFF
--- a/backend/src/main/java/com/skapp/community/crmplanner/controller/v2/CrmTaskControllerV2.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/controller/v2/CrmTaskControllerV2.java
@@ -1,0 +1,88 @@
+package com.skapp.community.crmplanner.controller.v2;
+
+import com.skapp.community.common.payload.response.ResponseEntityDto;
+import com.skapp.community.crmplanner.payload.request.CrmTaskCompletedFilterDto;
+import com.skapp.community.crmplanner.payload.request.CrmTaskCreateRequestDto;
+import com.skapp.community.crmplanner.payload.request.CrmTaskEditRequestDto;
+import com.skapp.community.crmplanner.payload.request.CrmTaskFilterDto;
+import com.skapp.community.crmplanner.payload.request.CrmTaskRelatedFilterDto;
+import com.skapp.community.crmplanner.service.v2.CrmTaskServiceV2;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v2/crm/task")
+@Tag(name = "CRM Tasks Controller V2", description = "Operations related to CRM Tasks")
+public class CrmTaskControllerV2 {
+
+	private final CrmTaskServiceV2 taskService;
+
+	@Operation(summary = "Get tasks",
+			description = "Returns all open non-deleted CRM tasks with search and filter by owner and deal.")
+	@GetMapping
+	@PreAuthorize("hasRole('ROLE_CRM_SALES_REPRESENTATIVE')")
+	public ResponseEntity<ResponseEntityDto> getTasks(CrmTaskFilterDto filterDto) {
+		ResponseEntityDto response = taskService.getTasks(filterDto);
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
+	@Operation(summary = "Get completed tasks",
+			description = "Returns a paginated list of completed non-deleted CRM tasks with search and filter by owner and deal.")
+	@GetMapping("/completed")
+	@PreAuthorize("hasRole('ROLE_CRM_SALES_REPRESENTATIVE')")
+	public ResponseEntity<ResponseEntityDto> getCompletedTasks(CrmTaskCompletedFilterDto filterDto) {
+		ResponseEntityDto response = taskService.getCompletedTasks(filterDto);
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
+	@Operation(summary = "Get related tasks",
+			description = "Returns paginated tasks filtered by contactId and/or dealId.")
+	@GetMapping("/related")
+	@PreAuthorize("hasRole('ROLE_CRM_SALES_REPRESENTATIVE')")
+	public ResponseEntity<ResponseEntityDto> getRelatedTasks(CrmTaskRelatedFilterDto filterDto) {
+		ResponseEntityDto response = taskService.getRelatedTasks(filterDto);
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
+	@Operation(summary = "Get CRM task by ID", description = "Returns CRM task details for the provided task ID.")
+	@GetMapping("/{id}")
+	@PreAuthorize("hasRole('ROLE_CRM_SALES_REPRESENTATIVE')")
+	public ResponseEntity<ResponseEntityDto> getTaskById(@PathVariable Long id) {
+		ResponseEntityDto response = taskService.getTaskById(id);
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
+	@Operation(summary = "Create a CRM task",
+			description = "Creates a task optionally linked to a contact, company and/or deal, "
+					+ "with the current user as owner unless an owner is specified.")
+	@PreAuthorize("hasRole('ROLE_CRM_SALES_REPRESENTATIVE')")
+	@PostMapping
+	public ResponseEntity<ResponseEntityDto> createTask(@RequestBody CrmTaskCreateRequestDto requestDto) {
+		ResponseEntityDto response = taskService.createTask(requestDto);
+		return new ResponseEntity<>(response, HttpStatus.CREATED);
+	}
+
+	@Operation(summary = "Edit task",
+			description = "Updates the provided fields of a task and returns the updated task")
+	@PatchMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+	@PreAuthorize("hasRole('ROLE_CRM_SALES_REPRESENTATIVE')")
+	public ResponseEntity<ResponseEntityDto> editTask(@PathVariable Long id,
+			@RequestBody CrmTaskEditRequestDto requestDto) {
+		ResponseEntityDto response = taskService.editTask(id, requestDto);
+		return new ResponseEntity<>(response, HttpStatus.OK);
+	}
+
+}

--- a/backend/src/main/java/com/skapp/community/crmplanner/mapper/CrmMapperV2.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/mapper/CrmMapperV2.java
@@ -2,8 +2,10 @@ package com.skapp.community.crmplanner.mapper;
 
 import com.skapp.community.crmplanner.model.CrmContact;
 import com.skapp.community.crmplanner.model.CrmDeal;
+import com.skapp.community.crmplanner.model.CrmTask;
 import com.skapp.community.crmplanner.payload.response.v2.CrmContactResponseDtoV2;
 import com.skapp.community.crmplanner.payload.response.v2.CrmDealResponseDtoV2;
+import com.skapp.community.crmplanner.payload.response.v2.CrmTaskResponseDtoV2;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring", uses = CrmMapper.class)
@@ -12,5 +14,7 @@ public interface CrmMapperV2 {
 	CrmContactResponseDtoV2 crmContactToCrmContactResponseDtoV2(CrmContact contact);
 
 	CrmDealResponseDtoV2 crmDealToCrmDealResponseDtoV2(CrmDeal deal);
+
+	CrmTaskResponseDtoV2 crmTaskToCrmTaskResponseDtoV2(CrmTask task);
 
 }

--- a/backend/src/main/java/com/skapp/community/crmplanner/payload/response/v2/CrmGetTasksResponseDtoV2.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/payload/response/v2/CrmGetTasksResponseDtoV2.java
@@ -1,0 +1,14 @@
+package com.skapp.community.crmplanner.payload.response.v2;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class CrmGetTasksResponseDtoV2 {
+
+	private List<CrmTaskResponseDtoV2> tasks;
+
+}

--- a/backend/src/main/java/com/skapp/community/crmplanner/payload/response/v2/CrmTaskResponseDtoV2.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/payload/response/v2/CrmTaskResponseDtoV2.java
@@ -1,0 +1,38 @@
+package com.skapp.community.crmplanner.payload.response.v2;
+
+import com.skapp.community.crmplanner.payload.response.CrmCompanyResponseDto;
+import com.skapp.community.crmplanner.payload.response.CrmOwnerResponseDto;
+import com.skapp.community.crmplanner.payload.response.CrmTaskTypeResponseDto;
+import com.skapp.community.crmplanner.type.CrmTaskPriority;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class CrmTaskResponseDtoV2 {
+
+	private Long id;
+
+	private String name;
+
+	private CrmTaskPriority priority;
+
+	private Boolean isCompleted;
+
+	private LocalDateTime dueAt;
+
+	private String notes;
+
+	private CrmTaskTypeResponseDto type;
+
+	private CrmOwnerResponseDto owner;
+
+	private CrmCompanyResponseDto company;
+
+	private CrmContactResponseDtoV2 contact;
+
+	private CrmDealResponseDtoV2 deal;
+
+}

--- a/backend/src/main/java/com/skapp/community/crmplanner/service/impl/CrmTaskServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/service/impl/CrmTaskServiceImpl.java
@@ -152,6 +152,13 @@ public class CrmTaskServiceImpl implements CrmTaskService {
 	@Override
 	@Transactional
 	public ResponseEntityDto createTask(CrmTaskCreateRequestDto requestDto) {
+		CrmTask savedTask = persistNewTask(requestDto);
+		return new ResponseEntityDto(false, crmMapper.crmTaskToCrmTaskResponseDto(savedTask));
+	}
+
+	@Override
+	@Transactional
+	public CrmTask persistNewTask(CrmTaskCreateRequestDto requestDto) {
 		log.info("createTask: execution started");
 
 		CrmValidations.validateTaskName(requestDto.getName());
@@ -197,7 +204,7 @@ public class CrmTaskServiceImpl implements CrmTaskService {
 		CrmTask savedTask = crmTaskDao.save(task);
 
 		log.info("createTask: execution ended with taskId={}", savedTask.getId());
-		return new ResponseEntityDto(false, crmMapper.crmTaskToCrmTaskResponseDto(savedTask));
+		return savedTask;
 	}
 
 	protected void validateTaskCreationLimit() {
@@ -207,6 +214,13 @@ public class CrmTaskServiceImpl implements CrmTaskService {
 	@Override
 	@Transactional
 	public ResponseEntityDto editTask(Long id, CrmTaskEditRequestDto requestDto) {
+		CrmTask updatedTask = applyTaskEdit(id, requestDto);
+		return new ResponseEntityDto(false, crmMapper.crmTaskToCrmTaskResponseDto(updatedTask));
+	}
+
+	@Override
+	@Transactional
+	public CrmTask applyTaskEdit(Long id, CrmTaskEditRequestDto requestDto) {
 		log.info("editTask: execution started");
 
 		CrmTask task = crmTaskDao.findByIdAndIsDeletedFalse(id)
@@ -285,7 +299,7 @@ public class CrmTaskServiceImpl implements CrmTaskService {
 		CrmTask updatedTask = crmTaskDao.save(task);
 
 		log.info("editTask: execution ended successfully");
-		return new ResponseEntityDto(false, crmMapper.crmTaskToCrmTaskResponseDto(updatedTask));
+		return updatedTask;
 	}
 
 	@Override

--- a/backend/src/main/java/com/skapp/community/crmplanner/service/v2/CrmTaskServiceV2.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/service/v2/CrmTaskServiceV2.java
@@ -1,31 +1,24 @@
-package com.skapp.community.crmplanner.service;
+package com.skapp.community.crmplanner.service.v2;
 
 import com.skapp.community.common.payload.response.ResponseEntityDto;
-import com.skapp.community.crmplanner.model.CrmTask;
 import com.skapp.community.crmplanner.payload.request.CrmTaskCompletedFilterDto;
 import com.skapp.community.crmplanner.payload.request.CrmTaskCreateRequestDto;
 import com.skapp.community.crmplanner.payload.request.CrmTaskEditRequestDto;
 import com.skapp.community.crmplanner.payload.request.CrmTaskFilterDto;
 import com.skapp.community.crmplanner.payload.request.CrmTaskRelatedFilterDto;
 
-public interface CrmTaskService {
+public interface CrmTaskServiceV2 {
 
 	ResponseEntityDto getTasks(CrmTaskFilterDto filterDto);
+
+	ResponseEntityDto getCompletedTasks(CrmTaskCompletedFilterDto filterDto);
+
+	ResponseEntityDto getRelatedTasks(CrmTaskRelatedFilterDto filterDto);
 
 	ResponseEntityDto getTaskById(Long id);
 
 	ResponseEntityDto createTask(CrmTaskCreateRequestDto requestDto);
 
-	CrmTask persistNewTask(CrmTaskCreateRequestDto requestDto);
-
 	ResponseEntityDto editTask(Long id, CrmTaskEditRequestDto requestDto);
-
-	CrmTask applyTaskEdit(Long id, CrmTaskEditRequestDto requestDto);
-
-	ResponseEntityDto deleteTask(Long id);
-
-	ResponseEntityDto getCompletedTasks(CrmTaskCompletedFilterDto filterDto);
-
-	ResponseEntityDto getRelatedTasks(CrmTaskRelatedFilterDto filterDto);
 
 }

--- a/backend/src/main/java/com/skapp/community/crmplanner/service/v2/impl/CrmTaskServiceImplV2.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/service/v2/impl/CrmTaskServiceImplV2.java
@@ -1,0 +1,151 @@
+package com.skapp.community.crmplanner.service.v2.impl;
+
+import com.skapp.community.common.exception.ModuleException;
+import com.skapp.community.common.model.User;
+import com.skapp.community.common.payload.response.PageDto;
+import com.skapp.community.common.payload.response.ResponseEntityDto;
+import com.skapp.community.common.service.UserService;
+import com.skapp.community.crmplanner.constant.CrmMessageConstant;
+import com.skapp.community.crmplanner.mapper.CrmMapperV2;
+import com.skapp.community.crmplanner.model.CrmTask;
+import com.skapp.community.crmplanner.payload.request.CrmTaskCompletedFilterDto;
+import com.skapp.community.crmplanner.payload.request.CrmTaskCreateRequestDto;
+import com.skapp.community.crmplanner.payload.request.CrmTaskEditRequestDto;
+import com.skapp.community.crmplanner.payload.request.CrmTaskFilterDto;
+import com.skapp.community.crmplanner.payload.request.CrmTaskRelatedFilterDto;
+import com.skapp.community.crmplanner.payload.response.v2.CrmGetTasksResponseDtoV2;
+import com.skapp.community.crmplanner.payload.response.v2.CrmTaskResponseDtoV2;
+import com.skapp.community.crmplanner.repository.CrmTaskDao;
+import com.skapp.community.crmplanner.service.CrmTaskService;
+import com.skapp.community.crmplanner.service.v2.CrmTaskServiceV2;
+import com.skapp.community.crmplanner.util.CrmUtil;
+import com.skapp.community.crmplanner.util.CrmValidations;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CrmTaskServiceImplV2 implements CrmTaskServiceV2 {
+
+	private final CrmTaskService crmTaskService;
+
+	private final CrmTaskDao crmTaskDao;
+
+	private final CrmMapperV2 crmMapperV2;
+
+	private final UserService userService;
+
+	@Override
+	@Transactional(readOnly = true)
+	public ResponseEntityDto getTasks(CrmTaskFilterDto filterDto) {
+		log.info("getTasks: execution started");
+
+		User currentUser = userService.getCurrentUser();
+		Long ownerId = CrmUtil.isCrmSalesRepresentative(currentUser) ? currentUser.getEmployee().getEmployeeId() : null;
+
+		List<CrmTaskResponseDtoV2> tasks = crmTaskDao.findTasks(ownerId, filterDto)
+			.stream()
+			.map(crmMapperV2::crmTaskToCrmTaskResponseDtoV2)
+			.toList();
+
+		CrmGetTasksResponseDtoV2 response = new CrmGetTasksResponseDtoV2();
+		response.setTasks(tasks);
+
+		log.info("getTasks: execution ended");
+		return new ResponseEntityDto(false, response);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public ResponseEntityDto getCompletedTasks(CrmTaskCompletedFilterDto filterDto) {
+		log.info("getCompletedTasks: execution started");
+
+		Pageable pageable = PageRequest.of(filterDto.getPage(), filterDto.getSize());
+
+		User currentUser = userService.getCurrentUser();
+		Long ownerId = CrmUtil.isCrmSalesRepresentative(currentUser) ? currentUser.getEmployee().getEmployeeId() : null;
+		Page<CrmTask> taskPage = crmTaskDao.findCompletedTasks(ownerId, filterDto, pageable);
+
+		log.info("getCompletedTasks: execution ended");
+		return new ResponseEntityDto(false, buildPageDto(taskPage));
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public ResponseEntityDto getRelatedTasks(CrmTaskRelatedFilterDto filterDto) {
+		log.info("getRelatedTasks: execution started");
+
+		CrmValidations.validateRelatedTaskContextFilter(filterDto.getContactId(), filterDto.getDealId());
+
+		User currentUser = userService.getCurrentUser();
+		Long ownerId = CrmUtil.isCrmSalesRepresentative(currentUser) ? currentUser.getEmployee().getEmployeeId() : null;
+
+		Pageable pageable = PageRequest.of(filterDto.getPage(), filterDto.getSize());
+		Page<CrmTask> taskPage = crmTaskDao.findRelatedTasks(filterDto, ownerId, pageable);
+
+		log.info("getRelatedTasks: execution ended");
+		return new ResponseEntityDto(false, buildPageDto(taskPage));
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public ResponseEntityDto getTaskById(Long id) {
+		log.info("getTaskById: execution started");
+
+		CrmTask task = crmTaskDao.findByIdWithAssociations(id)
+			.orElseThrow(() -> new ModuleException(CrmMessageConstant.CRM_ERROR_TASK_NOT_FOUND));
+
+		User currentUser = userService.getCurrentUser();
+		if (CrmValidations.isOwnerRestrictedForRepresentative(currentUser, task.getOwner().getEmployeeId())) {
+			throw new ModuleException(CrmMessageConstant.CRM_ERROR_TASK_VIEW_DENIED);
+		}
+
+		log.info("getTaskById: execution ended");
+		return new ResponseEntityDto(false, crmMapperV2.crmTaskToCrmTaskResponseDtoV2(task));
+	}
+
+	@Override
+	@Transactional
+	public ResponseEntityDto createTask(CrmTaskCreateRequestDto requestDto) {
+		log.info("createTask: execution started");
+
+		CrmTask savedTask = crmTaskService.persistNewTask(requestDto);
+
+		log.info("createTask: execution ended");
+		return new ResponseEntityDto(false, crmMapperV2.crmTaskToCrmTaskResponseDtoV2(savedTask));
+	}
+
+	@Override
+	@Transactional
+	public ResponseEntityDto editTask(Long id, CrmTaskEditRequestDto requestDto) {
+		log.info("editTask: execution started");
+
+		CrmTask updatedTask = crmTaskService.applyTaskEdit(id, requestDto);
+
+		log.info("editTask: execution ended");
+		return new ResponseEntityDto(false, crmMapperV2.crmTaskToCrmTaskResponseDtoV2(updatedTask));
+	}
+
+	private PageDto buildPageDto(Page<CrmTask> taskPage) {
+		List<CrmTaskResponseDtoV2> tasks = taskPage.getContent()
+			.stream()
+			.map(crmMapperV2::crmTaskToCrmTaskResponseDtoV2)
+			.toList();
+
+		PageDto pageDto = new PageDto();
+		pageDto.setItems(tasks);
+		pageDto.setCurrentPage(taskPage.getNumber());
+		pageDto.setTotalItems(taskPage.getTotalElements());
+		pageDto.setTotalPages(taskPage.getTotalPages());
+		return pageDto;
+	}
+
+}


### PR DESCRIPTION
## CRM v2 — Task (response-type refactor)

Stacked on #1732. Adds the `/v2/crm/task` endpoints returning the fully-embedded
`TaskResponse`. **No v1 API is changed.**

> Base is `feat/crm-deal-v2` (PR #1732). Review order: #1731 → #1732 → this. This
> PR shows only the task diff and will retarget up the stack as the lower PRs merge.

### Task
- `GET /v2/crm/task` (open), `GET /completed`, `GET /related`, `GET /{id}`, `POST`, `PATCH /{id}`
  → `CrmTaskResponseDtoV2` with fully embedded `type`, `owner`, `company`, `contact`, and `deal`
  (the contact and deal carry their own nested company/owner) — deepest self-contained shape, no cycles.
- Open-list keeps the v1 `{ tasks: [...] }` envelope via `CrmGetTasksResponseDtoV2`; the other reads stay paginated.
- Reads preserve the sales-rep owner restriction; `/related` keeps the contact/deal context validation.
- Writes delegate to v1 `persistNewTask` / `applyTaskEdit` (additive extraction; existing behavior unchanged) so the enterprise task-limit still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
