### PR TITLE
fix: adjust dropdown width in DealNameStageSection and DealProperties…

### DIFF
--- a/frontend/src/community/crm/components/organisms/AddDealSidePanel/DealNameStageSection.tsx
+++ b/frontend/src/community/crm/components/organisms/AddDealSidePanel/DealNameStageSection.tsx
@@ -86,9 +86,9 @@ const DealNameStageSection: FC<DealNameStageSectionProps> = ({
         />
       </div>
       <div className="w-1/3 pt-6.5">
-        <div className="w-[219px] max-w-full">
+        <div className="w-full max-w-[13.688rem]">
           {isStagesLoading ? (
-            <MultipleSkeletons numOfSkeletons={1} height={38} />
+            <MultipleSkeletons numOfSkeletons={1} height={48} />
           ) : (
             <Dropdown
               options={stageOptions}

--- a/frontend/src/community/crm/components/organisms/AddDealSidePanel/DealNameStageSection.tsx
+++ b/frontend/src/community/crm/components/organisms/AddDealSidePanel/DealNameStageSection.tsx
@@ -86,22 +86,24 @@ const DealNameStageSection: FC<DealNameStageSectionProps> = ({
         />
       </div>
       <div className="w-1/3 pt-6.5">
-        {isStagesLoading ? (
-          <MultipleSkeletons numOfSkeletons={1} height={38} />
-        ) : (
-          <Dropdown
-            options={stageOptions}
-            value={formik.values.stageId}
-            onChange={(v) => formik.setFieldValue("stageId", v)}
-            variant={stageDropdownVariant}
-            className="rounded-lg"
-            width="55%"
-            placeholder={translateText(["placeholders", "stage"])}
-            required
-            errorMessage={stageErrorMessage}
-            ariaLabel={translateText(["ariaLabels", "stage"])}
-          />
-        )}
+        <div className="w-[219px] max-w-full">
+          {isStagesLoading ? (
+            <MultipleSkeletons numOfSkeletons={1} height={38} />
+          ) : (
+            <Dropdown
+              options={stageOptions}
+              value={formik.values.stageId}
+              onChange={(v) => formik.setFieldValue("stageId", v)}
+              variant={stageDropdownVariant}
+              className="rounded-lg"
+              width="100%"
+              placeholder={translateText(["placeholders", "stage"])}
+              required
+              errorMessage={stageErrorMessage}
+              ariaLabel={translateText(["ariaLabels", "stage"])}
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/community/crm/components/organisms/DealSidePanel/DealPropertiesSidebar.tsx
+++ b/frontend/src/community/crm/components/organisms/DealSidePanel/DealPropertiesSidebar.tsx
@@ -112,20 +112,22 @@ const DealPropertiesSidebar: FC<DealPropertiesSidebarProps> = ({
 
   return (
     <div className="w-1/3 flex flex-col gap-4 shrink-0">
-      {isStagesLoading ? (
-        <SkeletonShape className="h-9 w-full" />
-      ) : (
-        <Dropdown
-          options={stageOptions}
-          value={selectedStageId}
-          onChange={handleStageChange}
-          variant="primary"
-          className="rounded-lg"
-          width="55%"
-          placeholder={translateText(["placeholders", "stage"])}
-          ariaLabel={translateText(["ariaLabels", "stage"])}
-        />
-      )}
+      <div className="w-[219px] max-w-full">
+        {isStagesLoading ? (
+          <SkeletonShape className="h-9 w-full" />
+        ) : (
+          <Dropdown
+            options={stageOptions}
+            value={selectedStageId}
+            onChange={handleStageChange}
+            variant="primary"
+            className="rounded-lg"
+            width="100%"
+            placeholder={translateText(["placeholders", "stage"])}
+            ariaLabel={translateText(["ariaLabels", "stage"])}
+          />
+        )}
+      </div>
 
       <div className="border border-secondary-accent rounded-lg p-3 flex flex-col gap-2 w-full">
         <PropertyRow label={translateText(["contact"])} required>

--- a/frontend/src/community/crm/components/organisms/DealSidePanel/DealPropertiesSidebar.tsx
+++ b/frontend/src/community/crm/components/organisms/DealSidePanel/DealPropertiesSidebar.tsx
@@ -26,7 +26,6 @@ import {
 import { validateDealAmount } from "~community/crm/utils/dealValidations";
 
 interface DealPropertiesSidebarProps {
-  isOpen?: boolean;
   onStageChange: (stageId: number) => void;
   onAmountChange: (amount: string) => void;
   onPriorityChange: (priority: CrmPriorityEnum) => void;
@@ -35,7 +34,6 @@ interface DealPropertiesSidebarProps {
 }
 
 const DealPropertiesSidebar: FC<DealPropertiesSidebarProps> = ({
-  isOpen,
   onStageChange,
   onAmountChange,
   onPriorityChange,
@@ -112,9 +110,9 @@ const DealPropertiesSidebar: FC<DealPropertiesSidebarProps> = ({
 
   return (
     <div className="w-1/3 flex flex-col gap-4 shrink-0">
-      <div className="w-[219px] max-w-full">
+      <div className="w-full max-w-[13.688rem]">
         {isStagesLoading ? (
-          <SkeletonShape className="h-9 w-full" />
+          <SkeletonShape className="h-12 w-full" />
         ) : (
           <Dropdown
             options={stageOptions}

--- a/frontend/src/community/crm/components/organisms/DealSidePanel/DealSidePanel.tsx
+++ b/frontend/src/community/crm/components/organisms/DealSidePanel/DealSidePanel.tsx
@@ -210,7 +210,6 @@ const DealSidePanel: FC = () => {
                 </div>
               </div>
               <DealPropertiesSidebar
-                isOpen={isOpen}
                 onStageChange={(stageId) => updateDeal({ stageId })}
                 onAmountChange={(amount) => updateDeal({ amount })}
                 onPriorityChange={(priority) => updateDeal({ priority })}

--- a/frontend/src/community/crm/components/organisms/DealSidePanel/DealSidePanelSkeleton.tsx
+++ b/frontend/src/community/crm/components/organisms/DealSidePanel/DealSidePanelSkeleton.tsx
@@ -44,7 +44,7 @@ const DealSidePanelSkeleton: FC = () => (
       </div>
 
       <div className="w-1/3 flex flex-col gap-4 shrink-0">
-        <div className="border border-secondary-accent rounded-lg px-3 py-2 flex items-center justify-between">
+        <div className="w-full max-w-[13.688rem] border border-secondary-accent rounded-lg px-3 py-2 flex items-center justify-between">
           <div className="flex items-center gap-2">
             <SkeletonShape circle className="h-2 w-2 shrink-0" />
             <SkeletonShape className="h-2.5 w-20" />


### PR DESCRIPTION
…Sidebar for better responsiveness

## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/[id]) 

### Summary

## Fix stage dropdown closing on clicks in empty space

### Problem
The stage dropdown's clickable/"inside" region was wider than the field itself. `Dropdown`
applies its `width` prop as an inline style on the trigger only, while its click-away check
tests the full-width root container. With `width="55%"`, the leftover 45% became an invisible
band that swallowed clicks at the field's row but counted as "outside" one row lower — so
clicking empty space next to the field behaved inconsistently.

### Fix
Let the container own the width and have the dropdown fill it (`width="100%"`) — the pattern
used by the other 15 `Dropdown` call sites in the codebase. Root, trigger and menu are now one
rectangle, so inside/outside matches what the user sees. Width set to the design's 219px.

- `DealPropertiesSidebar.tsx` — deal side panel stage field
- `DealNameStageSection.tsx` — add-deal side panel stage field

Also moved the loading skeleton inside the sized wrapper so the field no longer jumps width
when stages finish loading, and added `max-w-full` so the fixed 219px clamps instead of
overflowing below the `md` breakpoint.

### Testing
- Open the stage dropdown in both panels, click the empty space to the right of the field →
  closes cleanly (previously inconsistent).
- Selecting a stage, Escape, and Tab-out still work.
- 219px renders as specced at ≥768px; clamps to the column below that without horizontal scroll.

### Notes
The root cause is in `skapp-ui`'s `Dropdown` (`width` sizes the trigger, click-away tests the
root), so any consumer passing a sub-100% width hits this. Fixed at the call sites here since
those were the only two in the codebase; the upstream fix is tracked separately.

Two things to decide before you post it:

1. The store-slice changes are on this same branch (crmCompaniesSlice, crmContactsSlice, crmDealsSlice, crmLookupSlice, crmTasksSlice, crmUiSlice are all modified, plus the refactor/crm-715-Store-Slice-Normalizing commits). If this PR is meant to be just the dropdown fix, it needs its own branch off main — otherwise the description above understates what reviewers will see.
2. The 219px claim — I took it from your message, not from a design file. If the ticket/Figma link is handy, worth pasting it in place of "the design's 219px".
### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
