### PR TITLE
[Fix] Restore the signup page broken by the tenantID migration

### DIFF
--- a/frontend/src/fallback/common/utils/tenantUtil.ts
+++ b/frontend/src/fallback/common/utils/tenantUtil.ts
@@ -10,6 +10,10 @@ export const isTenantSelectionHost = (): boolean => false;
 
 export const getTenantId = (): string => "";
 
+export const isNotOnAppSubdomain = (): boolean => false;
+
+export const getAppSubdomainUrl = (): string => "";
+
 export const getTenantHostUrl = (): string => "";
 
 export const getTenantQueryPath = (): string => "";


### PR DESCRIPTION
## Summary

PR #773 deleted `getTenantID` and narrowed `getSubdomain` to a single argument, but left two helpers in the enterprise `commonUtil` still calling the old API. Because `next.config.mjs` sets `ignoreBuildErrors`, those broken references shipped as a green build and threw `ReferenceError: getTenantID is not defined` on the first render of the sign-up page — taking sign-up down on **every** host, not only tenant subdomains.

This moves both helpers into `tenantUtil` and rebuilds them on the existing `getHostSubdomain()`, preserving the pre-#773 behaviour exactly, and clears one further dangling import of the same shape.

## Changes in this repo (`SkappHQ/skapp`)

- Added `isNotOnAppSubdomain` and `getAppSubdomainUrl` stubs to `frontend/src/fallback/common/utils/tenantUtil.ts`, so the community fallback keeps mirroring the enterprise module's export surface as the two helpers move into it.
## Feature scope (all repos)

This fix spans multiple repos on branch `fix/signup-failure`:

| Repo | What changed |
|------|--------------|
| `SkappHQ/skapp` (super) | Fallback stubs so the community `tenantUtil` keeps mirroring the enterprise module's exports |
| `rootcodelabs/skapp-ep-fe-src` | Moved the two broken helpers into `tenantUtil`; removed an unreachable branch with the same dangling-import defect |
| `rootcodelabs/skapp-ep-fe-pages` | Repointed the `signup.tsx` imports at `tenantUtil` |

## Architecture / flow

```mermaid
flowchart TD
    A["User opens /signup"] --> B{"isNotOnAppSubdomain()"}
    B -- "on a tenant host" --> C["getAppSubdomainUrl(/signup + query)"]
    C --> D["window.location.replace to the app host"]
    D --> E["Sign-up form renders"]
    B -- "already on the app host" --> E

    subgraph Broken ["Before — broken on every host"]
        X["isNotOnAppSubdomain() in commonUtil"] --> Y["calls getTenantID(), deleted by #773"]
        Y --> Z["ReferenceError caught by ErrorBoundary<br/>sign-up page replaced by an error screen"]
    end
```

The helpers move module, not behaviour: `getHostSubdomain()` returns the first
host label, exactly what the deleted `getTenantID()` returned, so the resolved
redirect target is byte-for-byte what it was before #773.

## Exclusions — deliberately NOT in this PR

- **Host-derivation hardening.** `getAppSubdomainUrl` strips the first label
  unconditionally, so a two-label host yields `app.<tld>` and `localhost:3000`
  yields `app.`, and the caller navigates without a trusted-origin check. These
  are pre-existing weaknesses carried over unchanged; fixing them here would have
  made this PR a behaviour change rather than a crash fix. Raised separately.
- **`SameSite=Strict` → `Lax` cookie change in `rootcodelabs/skapp-pm`** — an
  unrelated local edit, kept out and raised on its own.
- **Pre-existing lint findings in the files touched** — the unused `sendEvent` in
  `signup.tsx` and the unused `React` / `tempData` in `InvoicePopupController`.
  All three predate this branch (baselined against HEAD) and are left for a
  dedicated clean-up.

## Ignored — handled elsewhere / at deployment

- **Submodule hash / pointer bumps** are intentionally excluded. Gitlink updates
  are done at **deployment time**, not in feature PRs.
- Untracked JVM crash logs (`hs_err_pid*.log`, `replay_pid*.log`) left in the
  workspace by an unrelated local run.

## Testing

| Check | Ran? | Result |
|-------|------|--------|
| Unit tests | n/a | No jest spec covers the sign-up flow |
| Formatter (BE only) | n/a | FE-only change |
| tsc + lint (BE only) | n/a | FE-only change — see note below |
| e2e (Playwright) | yes | **pass** — 3/3 (`auth` + `smoke`) |

`tsc` was diffed anyway, because this bug is precisely what a green build hides:
`next.config.mjs` sets `ignoreBuildErrors`, so the broken references compiled and
shipped. Baselined by `file(line,col): TScode` before and after — **665 → 661
errors, no new ones**. The four cleared are exactly this defect:

```
commonUtil.ts(52,20)             TS2552  Cannot find name 'getTenantID'
commonUtil.ts(60,21)             TS2352  bad cast on getSubdomain
commonUtil.ts(60,40)             TS2554  getSubdomain expects 1 argument, got 2
InvoicePopupController.tsx(7,10) TS2305  no exported member 'tempShouldUseCustomDashboard'
```

The e2e guard was verified non-vacuous: reverted to HEAD, `signup-page.spec.ts`
fails (times out waiting for the form, page sitting in the ErrorBoundary);
restored, it passes. Prettier clean; eslint reports only the pre-existing
findings listed under Exclusions.

## Related PRs

Same branch (`fix/signup-failure`), same fix, split across the repos it touches:

- SkappHQ/skapp#1748 — community fallback stubs for the relocated helpers
- rootcodelabs/skapp-ep-fe-src#778 — the crash fix; helpers moved into `tenantUtil`, plus the unreachable invoice branch
- rootcodelabs/skapp-ep-fe-pages#349 — `signup.tsx` import repoint

Merge order does not matter: each repo compiles independently, since the pages
change only repoints an import that both the old and new module resolve.

Raised alongside these but a **separate concern on its own branch**, not part of
this fix:

- rootcodelabs/skapp-pm#1217 — access-token cookie `SameSite` alignment (`fix/pm-access-token-samesite`)
