### PR TITLE
[Feat] Serve auth host frontend under the /auth path prefix

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,10 +1,24 @@
+const isEnterpriseMode = process.env.NEXT_PUBLIC_MODE === "enterprise";
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "standalone",
   reactStrictMode: false,
+  assetPrefix: isEnterpriseMode ? "/auth" : undefined,
   async rewrites() {
-    const isEnterpriseMode = process.env.NEXT_PUBLIC_MODE === "enterprise";
     return [
+      {
+        source: "/auth/signin",
+        destination: "/enterprise/auth/signin"
+      },
+      {
+        source: "/auth/oauth-consent",
+        destination: "/enterprise/auth/oauth-consent"
+      },
+      {
+        source: "/auth/redirect",
+        destination: "/enterprise/auth/redirect"
+      },
       {
         source: "/welcome",
         destination: "/community/welcome"
@@ -46,10 +60,6 @@ const nextConfig = {
         destination: isEnterpriseMode
           ? "/enterprise/signin"
           : "/community/signin"
-      },
-      {
-        source: "/oauth-consent",
-        destination: "/enterprise/oauth-consent"
       },
       {
         source: "/settings",
@@ -254,10 +264,6 @@ const nextConfig = {
       {
         source: "/redirect",
         destination: "/enterprise/redirect"
-      },
-      {
-        source: "/oauth-consent",
-        destination: "/enterprise/oauth-consent"
       },
       {
         source: "/verify/reset-password",

--- a/frontend/src/community/common/constants/routes.ts
+++ b/frontend/src/community/common/constants/routes.ts
@@ -200,3 +200,8 @@ export const nonSuperAdminRestrictedRoutes = [
 export const managerRestrictedRoutes = [ROUTES.PEOPLE.ADD];
 
 export const userRolesRestrictedRoutes = [ROUTES.CONFIGURATIONS.USER_ROLES];
+
+export const oAuthCallbackRoutes = [
+  ROUTES.AUTH.OAUTH_AUTHORIZE,
+  ROUTES.AUTH.OAUTH_CONSENT
+];

--- a/frontend/src/community/common/constants/routes.ts
+++ b/frontend/src/community/common/constants/routes.ts
@@ -18,7 +18,9 @@ const ROUTES = {
     FORGET_PASSWORD: "/forget-password",
     SYSTEM_UPDATE: "/system-update",
     OAUTH_AUTHORIZE: "/oauth2/authorize",
-    OAUTH_CONSENT: "/oauth-consent"
+    OAUTH_SIGNIN: "/auth/signin",
+    OAUTH_CONSENT: "/auth/oauth-consent",
+    OAUTH_REDIRECT: "/auth/redirect"
   },
   ORGANIZATION: {
     SETUP: "/setup-organization",


### PR DESCRIPTION
## Summary

The AWS ALB routes the OAuth issuer host `auth.skapp.dev` by path: `/auth*` goes to the core frontend, everything else (`/*`) to the core backend. This serves the OAuth 2.1 browser leg from **dedicated pages under `/auth`**, so the shared tenant sign-in page no longer carries any auth-host or OAuth branching.

## Changes in this repo (`SkappHQ/skapp`)

- `next.config.mjs`: `assetPrefix` set to `/auth` in enterprise mode, plus three ordinary page rewrites in the existing array (`/auth/signin`, `/auth/oauth-consent`, `/auth/redirect`). **No `beforeFiles`, no `images` config, no new top-level constants** — `rewrites()` still returns a plain array, exactly the existing pattern used by the other 109 routes.
- **Removed both duplicate root `/oauth-consent` rewrites.** Consent only exists inside the OAuth flow, so it now lives solely at `/auth/oauth-consent`.
- `routes.ts`: `OAUTH_SIGNIN`, `OAUTH_CONSENT`, `OAUTH_REDIRECT` are literal `/auth/*` paths.

### Why the pages are rewrites, not real `/auth/*` files

`frontend/pages/enterprise` is a git submodule mounted at `/enterprise/*`, and a submodule cannot be mounted twice. Real `pages/auth/*` files would therefore have to sit in this (community) repo while importing `~enterprise` components — which breaks community builds when the submodule is empty. The rewrite is what lets a submodule-owned page answer at a super-repo URL. Every one of the other 114 routes works this way.

### Why `assetPrefix` is the one unavoidable addition

Everything else was stripped out and re-tested. `assetPrefix` cannot be:

Without it, the browser is told to fetch `/_next/static/*` **unprefixed**, which the ALB default rule sends to the backend. Measured: page HTML returns `200`, then **11 chunk requests 404** and the page sits on its loading spinner forever — the domain field never renders. `assetPrefix` is the only mechanism that changes what the browser asks for.

With it, `_next/static/*` and `public/` files resolve **natively — no rewrite needed** (verified: correct MIME types, byte-identical payloads). The logo uses a static import, so it is served as `/auth/_next/static/media/logo.<hash>.png` and the image optimizer is not involved at all.

The three page rewrites are ordinary `afterFiles` entries, identical in shape to `/signin → /enterprise/signin`.

## Feature scope (all repos)

This feature spans multiple repos on branch `feat/oauth-fe-route-changes`:

| Repo | What changed |
|------|--------------|
| `SkappHQ/skapp` (super) | `assetPrefix` + three page rewrites in the existing array, `/auth/*` route constants, duplicate consent rewrites removed |
| `rootcodelabs/skapp-ep-fe-src` | OAuth callback/method query-param constants, `buildSsoReturnUrl` |
| `rootcodelabs/skapp-ep-fe-pages` | **New** `auth/signin`, `auth/redirect`; consent **moved** to `auth/oauth-consent`; OAuth branching removed from shared `signin`/`redirect` |
| `rootcodelabs/skapp-ep-be-src` | `OAUTH_SIGN_IN_PATH` / `OAUTH_CONSENT_PAGE` composed from an `/auth` prefix constant |

## Architecture / flow

```mermaid
flowchart LR
    C[Claude MCP client] -->|/oauth2/authorize| ALB{ALB rule<br/>auth.skapp.dev}
    ALB -->|/auth*| FE[core FE]
    ALB -->|/* default| BE[core BE]
    BE -->|302 /auth/signin?callback=| P1[enterprise/auth/signin]
    P1 -->|credentials| S[POST /v1/auth/oauth/session-login]
    P1 -->|SSO| P3[enterprise/auth/redirect]
    P3 --> S
    S --> BE
    BE -->|302 /auth/oauth-consent| P2[enterprise/auth/oauth-consent]
    P2 -->|approve| BE
    BE -->|302 code| C
```

## Exclusions — deliberately NOT in this PR

- **The raw `fetch` in `AuthProvider.signIn`** stays a raw `fetch`. Pre-existing, and it targets a same-origin Next API route rather than the backend; routing it through `authFetchSameOrigin` would attach the auth/tenant interceptors and call `getAccessToken()` during sign-in, before credentials exist. Only the path changed.
- **`?? ""` in `getSafeOAuthCallback`** — pre-existing normalisation of `URLSearchParams.get()`, which returns `null`. The function's public contract still returns `undefined` for absent.
- **Optimising a fixed-size PNG logo through `next/image`** is wasteful, but pre-existing across 13 files. A static import in `SkappLogo` is the right fix and belongs in its own PR.

## Ignored — handled elsewhere / at deployment

- **Submodule hash / pointer bumps** are intentionally excluded. Gitlink updates happen at **deployment time**, not in feature PRs.
- **ALB configuration.** The path pattern must be `/auth*` (or `/auth/*`) — ALB matches `/auth` literally, so `/auth/signin` would miss the rule.
- **CDN behaviours keyed on `/_next/*`** must become `/auth/_next/*`; `assetPrefix` changes asset URLs on every host.
- **`/api/clear-cookies` is no longer prefixed on the auth host**, so the pre-sign-in cookie clear silently no-ops there (`fetch` resolves on 404). Deliberate: that endpoint clears every cookie for the domain, which on `.skapp.dev` would drop other tenants' refresh tokens and the shared `tenant` cookie that session detection relies on. Sign-in verified working without it.
- **`/_next/data/*` is not prefixed by `assetPrefix`** — not an issue here, as all three auth-host pages are purely client-rendered (no `getServerSideProps`/`getStaticProps`), so Next issues no data requests for them. It would matter if a future auth-host page added server-side data fetching.

## Testing

| Check | Ran? | Result |
|-------|------|--------|
| Unit tests | n/a | No existing spec covers the changed modules; verified by live flow below |
| Formatter (BE only) | yes | `mvn checkstyle:check` pass |
| tsc + lint (BE only) | yes | `mvn compile` pass. FE `tsc` re-baselined against current `develop` after rebase — **655 before, 655 after, identical per file+code**. `next lint` clean, prettier clean |
| e2e (Playwright) | yes | Full OAuth flow driven in a real browser against `https://auth.skapp.dev` — pass |

Verified with nginx locally mirroring the ALB topology (`/auth*` → FE, `/*` → BE) on the real hostname, with the stored consent row deleted first so the consent screen was genuinely exercised:

- Backend `302` on unauthenticated `/oauth2/authorize` targets `/auth/signin?callback=…`
- Request trail served the **new** chunks: `pages/enterprise/auth/signin`, `pages/enterprise/auth/oauth-consent`
- `/auth/signin`, `/auth/oauth-consent`, `/auth/redirect` → `200`; `/auth/_next/static/*` and the static-import logo → `200` with correct MIME, **no rewrite covering them**; browser run shows **zero failed requests**
- Sign-in → `session-login` → consent → `claude.ai/api/mcp/auth_callback?code=…` issued a real authorization code; consent row and master authorization confirmed in MySQL
- Old root `/oauth-consent` now `404` on tenant hosts, as intended
- Tenant host regression-checked: `/signin` 200, `/dashboard` 307 (auth redirect), `/redirect` 200, `/api/clear-cookies` 200 — all unaffected
- **Counter-test**: with `assetPrefix` removed, page HTML still returned `200` but 11 chunks 404'd and the page hung on its spinner — which is why it is the one addition that stays

## Related PRs

Same branch `feat/oauth-fe-route-changes` in every repo; all four merge together — the auth host is broken with a partial merge.

- SkappHQ/skapp#1750 — super repo: rewrites, assetPrefix, route constants
- rootcodelabs/skapp-ep-fe-src#779 — callback constants, SSO return URL builder
- rootcodelabs/skapp-ep-fe-pages#350 — dedicated `auth/*` pages; OAuth branching removed from shared pages
- rootcodelabs/skapp-ep-be-src#747 — backend sign-in + consent page constants
