### PR TITLE
feat(crm): return task types in board init-data endpoint

### DIFF
--- a/backend/src/main/java/com/skapp/community/crmplanner/controller/v1/CrmBoardController.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/controller/v1/CrmBoardController.java
@@ -27,7 +27,7 @@ public class CrmBoardController {
 	private final CrmDealService crmDealService;
 
 	@Operation(summary = "Get board init data",
-			description = "Returns all data required for the kanban board initial load: stages, contacts, CRM roles, and owners.")
+			description = "Returns all data required for the kanban board initial load: stages, contacts, CRM roles, owners, and task types.")
 	@GetMapping("/init-data")
 	@PreAuthorize("hasAnyRole('ROLE_CRM_SALES_REPRESENTATIVE')")
 	public ResponseEntity<ResponseEntityDto> getBoardInitData() {

--- a/backend/src/main/java/com/skapp/community/crmplanner/payload/response/board/CrmBoardInitDataResponseDto.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/payload/response/board/CrmBoardInitDataResponseDto.java
@@ -1,5 +1,6 @@
 package com.skapp.community.crmplanner.payload.response.board;
 
+import com.skapp.community.crmplanner.payload.response.CrmTaskTypeResponseDto;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -16,5 +17,7 @@ public class CrmBoardInitDataResponseDto {
 	private List<String> crmRoles;
 
 	private List<CrmBoardOwnerResponseDto> owners;
+
+	private List<CrmTaskTypeResponseDto> taskTypes;
 
 }

--- a/backend/src/main/java/com/skapp/community/crmplanner/service/impl/CrmDealServiceImpl.java
+++ b/backend/src/main/java/com/skapp/community/crmplanner/service/impl/CrmDealServiceImpl.java
@@ -24,6 +24,7 @@ import com.skapp.community.crmplanner.payload.request.CrmDealReorderRequestDto;
 import com.skapp.community.crmplanner.payload.request.board.CrmDealsByStagesRequestDto;
 import com.skapp.community.crmplanner.payload.response.CrmExistsResponseDto;
 import com.skapp.community.crmplanner.payload.response.CrmDealResponseDto;
+import com.skapp.community.crmplanner.payload.response.CrmTaskTypeResponseDto;
 import com.skapp.community.crmplanner.payload.response.board.CrmBoardContactResponseDto;
 import com.skapp.community.crmplanner.payload.response.board.CrmBoardInitDataResponseDto;
 import com.skapp.community.crmplanner.payload.response.board.CrmBoardOwnerResponseDto;
@@ -36,6 +37,7 @@ import com.skapp.community.crmplanner.repository.CrmContactOwnerRepository;
 import com.skapp.community.crmplanner.repository.CrmDealDao;
 import com.skapp.community.crmplanner.repository.CrmDealStageDao;
 import com.skapp.community.crmplanner.repository.CrmTaskDao;
+import com.skapp.community.crmplanner.repository.CrmTaskTypeDao;
 import com.skapp.community.crmplanner.service.CrmDealService;
 import com.skapp.community.crmplanner.service.CrmOwnerResolverService;
 import com.skapp.community.crmplanner.util.CrmUtil;
@@ -78,6 +80,8 @@ public class CrmDealServiceImpl implements CrmDealService {
 	private final CrmOwnerResolverService crmOwnerResolver;
 
 	private final CrmTaskDao crmTaskDao;
+
+	private final CrmTaskTypeDao crmTaskTypeDao;
 
 	private final MessageUtil messageUtil;
 
@@ -264,11 +268,15 @@ public class CrmDealServiceImpl implements CrmDealService {
 					o.getAuthPic()))
 			.toList();
 
+		List<CrmTaskTypeResponseDto> taskTypes = crmMapper
+			.crmTaskTypesToCrmTaskTypeResponseDtos(crmTaskTypeDao.findAllByOrderByOrderIndexAscIdAsc());
+
 		CrmBoardInitDataResponseDto responseDto = new CrmBoardInitDataResponseDto();
 		responseDto.setStages(stages);
 		responseDto.setContacts(contacts);
 		responseDto.setCrmRoles(CrmConstants.ASSIGNABLE_CRM_ROLES.stream().map(Enum::name).sorted().toList());
 		responseDto.setOwners(owners);
+		responseDto.setTaskTypes(taskTypes);
 
 		log.info("getBoardInitData: execution ended");
 		return new ResponseEntityDto(false, responseDto);

--- a/backend/src/test/java/com/skapp/community/crmplanner/controller/v1/CrmBoardControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/crmplanner/controller/v1/CrmBoardControllerIntegrationTest.java
@@ -106,6 +106,8 @@ class CrmBoardControllerIntegrationTest {
 
 	private CrmTaskType taskType;
 
+	private CrmTaskType emailTaskType;
+
 	@BeforeEach
 	void setup() {
 		adminToken = jwtService.generateAccessToken(userDetailsService.loadUserByUsername("user1@gmail.com"), 1L);
@@ -134,9 +136,14 @@ class CrmBoardControllerIntegrationTest {
 		contact.setOwner(employeeDao.getReferenceById(1L));
 		crmContactDao.save(contact);
 
+		emailTaskType = new CrmTaskType();
+		emailTaskType.setName("Email");
+		emailTaskType.setOrderIndex(1);
+		emailTaskType = crmTaskTypeDao.save(emailTaskType);
+
 		taskType = new CrmTaskType();
 		taskType.setName("Call");
-		taskType.setOrderIndex(1);
+		taskType.setOrderIndex(2);
 		taskType = crmTaskTypeDao.save(taskType);
 	}
 
@@ -456,11 +463,29 @@ class CrmBoardControllerIntegrationTest {
 			.andDo(print())
 			.andExpect(status().isOk())
 			.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+			.andExpect(jsonPath(RESULTS_0_PATH + "['stages']").isArray())
+			.andExpect(jsonPath(RESULTS_0_PATH + "['stages']").isNotEmpty())
+			.andExpect(jsonPath(RESULTS_0_PATH + "['contacts']").isArray())
+			.andExpect(jsonPath(RESULTS_0_PATH + "['contacts']").isNotEmpty())
+			.andExpect(jsonPath(RESULTS_0_PATH + "['owners']").isArray())
+			.andExpect(jsonPath(RESULTS_0_PATH + "['crmRoles']").isArray())
 			.andExpect(jsonPath(RESULTS_0_PATH + "['taskTypes']").isArray())
-			.andExpect(jsonPath(RESULTS_0_PATH + "['taskTypes'][?(@.name=='Call')]").exists())
-			.andExpect(jsonPath(RESULTS_0_PATH + "['taskTypes'][0]['id']").value(taskType.getId()))
-			.andExpect(jsonPath(RESULTS_0_PATH + "['taskTypes'][0]['name']").value("Call"))
-			.andExpect(jsonPath(RESULTS_0_PATH + "['taskTypes'][0]['orderIndex']").value(1));
+			.andExpect(jsonPath(RESULTS_0_PATH + "['taskTypes'][0]['id']").value(emailTaskType.getId()))
+			.andExpect(jsonPath(RESULTS_0_PATH + "['taskTypes'][0]['name']").value("Email"))
+			.andExpect(jsonPath(RESULTS_0_PATH + "['taskTypes'][0]['orderIndex']").value(1))
+			.andExpect(jsonPath(RESULTS_0_PATH + "['taskTypes'][1]['id']").value(taskType.getId()))
+			.andExpect(jsonPath(RESULTS_0_PATH + "['taskTypes'][1]['name']").value("Call"))
+			.andExpect(jsonPath(RESULTS_0_PATH + "['taskTypes'][1]['orderIndex']").value(2));
+	}
+
+	@Test
+	@DisplayName("Board init data - without CRM role returns Forbidden")
+	void getBoardInitData_WithoutCrmRole_ReturnsForbidden() throws Exception {
+		String noCrmRoleToken = jwtService.generateAccessToken(userDetailsService.loadUserByUsername("user4@gmail.com"),
+				1L);
+
+		mvc.perform(get("/v1/crm/board/init-data").accept(MediaType.APPLICATION_JSON)
+			.with(SecurityTestUtils.bearerToken(noCrmRoleToken))).andDo(print()).andExpect(status().isForbidden());
 	}
 
 	private CrmTask createTask(CrmDeal deal) {

--- a/backend/src/test/java/com/skapp/community/crmplanner/controller/v1/CrmBoardControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/crmplanner/controller/v1/CrmBoardControllerIntegrationTest.java
@@ -48,6 +48,7 @@ import static com.skapp.support.TestConstants.STATUS_UNSUCCESSFUL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -445,6 +446,21 @@ class CrmBoardControllerIntegrationTest {
 			.content(objectMapper.writeValueAsString(dto))
 			.accept(MediaType.APPLICATION_JSON)
 			.with(SecurityTestUtils.bearerToken(token)));
+	}
+
+	@Test
+	@DisplayName("Board init data - returns task types ordered by orderIndex")
+	void getBoardInitData_ReturnsTaskTypes() throws Exception {
+		mvc.perform(get("/v1/crm/board/init-data").accept(MediaType.APPLICATION_JSON)
+			.with(SecurityTestUtils.bearerToken(repToken)))
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath(STATUS_PATH).value(STATUS_SUCCESSFUL))
+			.andExpect(jsonPath(RESULTS_0_PATH + "['taskTypes']").isArray())
+			.andExpect(jsonPath(RESULTS_0_PATH + "['taskTypes'][?(@.name=='Call')]").exists())
+			.andExpect(jsonPath(RESULTS_0_PATH + "['taskTypes'][0]['id']").value(taskType.getId()))
+			.andExpect(jsonPath(RESULTS_0_PATH + "['taskTypes'][0]['name']").value("Call"))
+			.andExpect(jsonPath(RESULTS_0_PATH + "['taskTypes'][0]['orderIndex']").value(1));
 	}
 
 	private CrmTask createTask(CrmDeal deal) {


### PR DESCRIPTION
## What

`GET /v1/crm/board/init-data` now returns `taskTypes` alongside the existing `stages`, `contacts`, `crmRoles`, and `owners`, so the kanban board can load task-type options in its initial payload instead of making a separate request.

## Changes

- **`CrmBoardInitDataResponseDto`** — added `List<CrmTaskTypeResponseDto> taskTypes`.
- **`CrmDealServiceImpl.getBoardInitData()`** — injected `CrmTaskTypeDao` and populated `taskTypes`, reusing the existing `crmTaskTypesToCrmTaskTypeResponseDtos` mapper and `findAllByOrderByOrderIndexAscIdAsc()` ordering (identical to the standalone task-types endpoint).
- **`CrmBoardControllerIntegrationTest`** — added `getBoardInitData_ReturnsTaskTypes` (the endpoint previously had no test coverage).

## Testing

`CrmBoardControllerIntegrationTest` — 16 tests, 0 failures. Full `mvn compile` clean.