### PR TITLE
fix: Auto-enable birthday notification sub-toggles on main toggle enable

### DIFF
--- a/frontend/src/community/configurations/components/organisms/PeopleConfigurations/PeopleConfigurations.tsx
+++ b/frontend/src/community/configurations/components/organisms/PeopleConfigurations/PeopleConfigurations.tsx
@@ -106,6 +106,14 @@ const PeopleConfigurations: FC = () => {
     }
   };
 
+  const handleMainToggleChange = (checked: boolean) => {
+    birthdayFormik.setFieldValue("isTurnedOn", checked);
+    if (checked) {
+      birthdayFormik.setFieldValue("isTeamWide", true);
+      birthdayFormik.setFieldValue("isOrganizationWide", true);
+    }
+  };
+
   const subOptionsAriaMessage = birthdayNotificationConfig
     ? translateText([
         "aria",
@@ -154,9 +162,7 @@ const PeopleConfigurations: FC = () => {
             labelId="birthday-notification"
             arialabel={translateText(["aria", "mainToggle"])}
             checked={birthdayFormik.values.isTurnedOn}
-            onChange={(checked) =>
-              birthdayFormik.setFieldValue("isTurnedOn", checked)
-            }
+            onChange={handleMainToggleChange}
           />
           {birthdayFormik.values.isTurnedOn && (
             <>

--- a/frontend/src/community/configurations/components/organisms/PeopleConfigurations/PeopleConfigurations.tsx
+++ b/frontend/src/community/configurations/components/organisms/PeopleConfigurations/PeopleConfigurations.tsx
@@ -106,11 +106,20 @@ const PeopleConfigurations: FC = () => {
     }
   };
 
-  const handleMainToggleChange = (checked: boolean) => {
+  const handleBirthdayNotificationToggle = (checked: boolean): void => {
     birthdayFormik.setFieldValue("isTurnedOn", checked);
     if (checked) {
       birthdayFormik.setFieldValue("isTeamWide", true);
       birthdayFormik.setFieldValue("isOrganizationWide", true);
+    } else {
+      birthdayFormik.setFieldValue(
+        "isTeamWide",
+        birthdayFormik.initialValues.isTeamWide
+      );
+      birthdayFormik.setFieldValue(
+        "isOrganizationWide",
+        birthdayFormik.initialValues.isOrganizationWide
+      );
     }
   };
 
@@ -162,7 +171,7 @@ const PeopleConfigurations: FC = () => {
             labelId="birthday-notification"
             arialabel={translateText(["aria", "mainToggle"])}
             checked={birthdayFormik.values.isTurnedOn}
-            onChange={handleMainToggleChange}
+            onChange={handleBirthdayNotificationToggle}
           />
           {birthdayFormik.values.isTurnedOn && (
             <>


### PR DESCRIPTION
In people configuration when birthday notifications are turned on the sub notification under it also should turn on automatically fixed this by setting the two to true when notifications are enabled.