### PR TITLE
fix: persist dismissed birthday modals to prevent them reappearing on refresh

### DIFF
--- a/frontend/src/community/people/constants/stringConstants.ts
+++ b/frontend/src/community/people/constants/stringConstants.ts
@@ -8,6 +8,8 @@ export const EMAIL_MAX_LENGTH = 100;
 export const BIRTHDAY_NOTIFICATION_VIEW_STATE_CACHE_KEY =
   "birthdayNotificationViewState";
 
+export const BIRTHDAY_DISMISSED_ENTRIES_CACHE_KEY = "birthdayDismissedEntries";
+
 export const PAYROLL_ID_LENGTH = 50;
 
 export const TIN_LENGTH = 50;

--- a/frontend/src/community/people/hooks/useBirthdayNotifications.ts
+++ b/frontend/src/community/people/hooks/useBirthdayNotifications.ts
@@ -15,6 +15,11 @@ import {
   MarkBirthdayNotificationsViewedResponse
 } from "~community/people/types/BirthdayNotificationTypes";
 import {
+  getDismissedEmployeeIds,
+  readDismissedCache,
+  writeDismissedCache
+} from "~community/people/utils/birthdayNotificationCacheUtils";
+import {
   buildBirthdayQueue,
   normalizeEmployeeId
 } from "~community/people/utils/birthdayNotificationUtils";
@@ -79,7 +84,16 @@ const useBirthdayNotifications = (): BirthdayNotificationsType => {
       currentEmployeeId
     );
 
-    if (birthdayQueue.length === 0) {
+    const dismissedEmployeeIds = getDismissedEmployeeIds(
+      readDismissedCache(),
+      today,
+      userId
+    );
+    const pendingQueue = birthdayQueue.filter(
+      (entry) => !dismissedEmployeeIds.includes(entry.employee.employeeId)
+    );
+
+    if (pendingQueue.length === 0) {
       if (data.lastViewedDate !== today) {
         markViewed();
       }
@@ -91,12 +105,13 @@ const useBirthdayNotifications = (): BirthdayNotificationsType => {
         ? document.activeElement
         : null;
     isShowingRef.current = true;
-    setQueue(birthdayQueue);
+    setQueue(pendingQueue);
     setCursor(0);
   }, [
     data,
     shouldEvaluate,
     today,
+    userId,
     currentEmployeeId,
     isCurrentEmployeeResolved,
     markViewed,
@@ -119,6 +134,25 @@ const useBirthdayNotifications = (): BirthdayNotificationsType => {
   }, [markViewed]);
 
   const onDismiss = useCallback(() => {
+    const dismissedEntry = queue[cursor];
+
+    if (dismissedEntry && userId !== undefined) {
+      const existingDismissedIds = getDismissedEmployeeIds(
+        readDismissedCache(),
+        today,
+        userId
+      );
+      const dismissedEmployeeId = dismissedEntry.employee.employeeId;
+
+      if (!existingDismissedIds.includes(dismissedEmployeeId)) {
+        writeDismissedCache({
+          userId,
+          date: today,
+          dismissedEmployeeIds: [...existingDismissedIds, dismissedEmployeeId]
+        });
+      }
+    }
+
     const nextCursor = cursor + 1;
 
     if (nextCursor < queue.length) {
@@ -127,7 +161,7 @@ const useBirthdayNotifications = (): BirthdayNotificationsType => {
     }
 
     finishSequence();
-  }, [cursor, queue.length, finishSequence]);
+  }, [cursor, queue, userId, today, finishSequence]);
 
   useEffect(() => {
     if (evaluationTick === 0) return;

--- a/frontend/src/community/people/hooks/useBirthdayNotifications.ts
+++ b/frontend/src/community/people/hooks/useBirthdayNotifications.ts
@@ -15,6 +15,7 @@ import {
   MarkBirthdayNotificationsViewedResponse
 } from "~community/people/types/BirthdayNotificationTypes";
 import {
+  clearDismissedCache,
   getDismissedEmployeeIds,
   readDismissedCache,
   writeDismissedCache
@@ -72,6 +73,7 @@ const useBirthdayNotifications = (): BirthdayNotificationsType => {
     if (!shouldEvaluate) return;
     if (isShowingRef.current) return;
     if (!isCurrentEmployeeResolved) return;
+    if (userId === undefined) return;
 
     seededDataRef.current = data;
 
@@ -136,7 +138,7 @@ const useBirthdayNotifications = (): BirthdayNotificationsType => {
   const onDismiss = useCallback(() => {
     const dismissedEntry = queue[cursor];
 
-    if (dismissedEntry && userId !== undefined) {
+    if (dismissedEntry && userId !== undefined && today) {
       const existingDismissedIds = getDismissedEmployeeIds(
         readDismissedCache(),
         today,
@@ -180,6 +182,7 @@ const useBirthdayNotifications = (): BirthdayNotificationsType => {
     restoreFocusRef.current = null;
     setQueue([]);
     setCursor(0);
+    clearDismissedCache();
   }, [userId]);
 
   return {

--- a/frontend/src/community/people/types/BirthdayNotificationTypes.ts
+++ b/frontend/src/community/people/types/BirthdayNotificationTypes.ts
@@ -40,6 +40,12 @@ export interface BirthdayNotificationViewStateType {
   lastViewedDate: string;
 }
 
+export interface BirthdayDismissedCacheType {
+  userId: number;
+  date: string;
+  dismissedEmployeeIds: number[];
+}
+
 export interface BirthdayNotificationContextType {
   isEligible: boolean;
   today: string;

--- a/frontend/src/community/people/utils/birthdayNotificationCacheUtils.ts
+++ b/frontend/src/community/people/utils/birthdayNotificationCacheUtils.ts
@@ -12,61 +12,22 @@ import {
   BirthdayNotificationViewStateType
 } from "~community/people/types/BirthdayNotificationTypes";
 
-const readCache = <T>(
-  key: string,
-  isValid: (value: unknown) => value is T
-): T | null => {
+export const readViewedCache = (): BirthdayNotificationViewStateType | null => {
   try {
-    const cachedValue = getDataFromLocalStorage(key);
+    const cachedValue = getDataFromLocalStorage(
+      BIRTHDAY_NOTIFICATION_VIEW_STATE_CACHE_KEY
+    );
 
-    if (!isValid(cachedValue)) return null;
+    if (!cachedValue || typeof cachedValue !== "object") return null;
+    if (typeof cachedValue.userId !== "number") return null;
+    if (typeof cachedValue.lastViewedDate !== "string") return null;
 
-    return cachedValue;
+    return cachedValue as BirthdayNotificationViewStateType;
   } catch {
-    removeDataFromLocalStorage(key);
+    removeDataFromLocalStorage(BIRTHDAY_NOTIFICATION_VIEW_STATE_CACHE_KEY);
     return null;
   }
 };
-
-const isViewedCacheShape = (
-  value: unknown
-): value is BirthdayNotificationViewStateType => {
-  const cache = value as BirthdayNotificationViewStateType;
-
-  return (
-    !!cache &&
-    typeof cache === "object" &&
-    typeof cache.userId === "number" &&
-    typeof cache.lastViewedDate === "string"
-  );
-};
-
-const isDismissedCacheShape = (
-  value: unknown
-): value is BirthdayDismissedCacheType => {
-  const cache = value as BirthdayDismissedCacheType;
-
-  return (
-    !!cache &&
-    typeof cache === "object" &&
-    typeof cache.userId === "number" &&
-    typeof cache.date === "string" &&
-    Array.isArray(cache.dismissedEmployeeIds)
-  );
-};
-
-const matchesUserAndDate = (
-  cacheUserId: number,
-  cacheDate: string,
-  today: string | null,
-  currentUserId: number | undefined
-): boolean => {
-  if (!today || currentUserId === undefined) return false;
-  return cacheUserId === currentUserId && cacheDate === today;
-};
-
-export const readViewedCache = (): BirthdayNotificationViewStateType | null =>
-  readCache(BIRTHDAY_NOTIFICATION_VIEW_STATE_CACHE_KEY, isViewedCacheShape);
 
 export const writeViewedCache = (
   cache: BirthdayNotificationViewStateType
@@ -78,12 +39,29 @@ export const isViewedToday = (
   cache: BirthdayNotificationViewStateType | null,
   today: string | null,
   currentUserId: number | undefined
-): boolean =>
-  !!cache &&
-  matchesUserAndDate(cache.userId, cache.lastViewedDate, today, currentUserId);
+): boolean => {
+  if (!cache || !today || currentUserId === undefined) return false;
+  if (cache.userId !== currentUserId) return false;
+  return cache.lastViewedDate === today;
+};
 
-export const readDismissedCache = (): BirthdayDismissedCacheType | null =>
-  readCache(BIRTHDAY_DISMISSED_ENTRIES_CACHE_KEY, isDismissedCacheShape);
+export const readDismissedCache = (): BirthdayDismissedCacheType | null => {
+  try {
+    const cachedValue = getDataFromLocalStorage(
+      BIRTHDAY_DISMISSED_ENTRIES_CACHE_KEY
+    );
+
+    if (!cachedValue || typeof cachedValue !== "object") return null;
+    if (typeof cachedValue.userId !== "number") return null;
+    if (typeof cachedValue.date !== "string") return null;
+    if (!Array.isArray(cachedValue.dismissedEmployeeIds)) return null;
+
+    return cachedValue as BirthdayDismissedCacheType;
+  } catch {
+    removeDataFromLocalStorage(BIRTHDAY_DISMISSED_ENTRIES_CACHE_KEY);
+    return null;
+  }
+};
 
 export const writeDismissedCache = (
   cache: BirthdayDismissedCacheType
@@ -99,7 +77,9 @@ export const getDismissedEmployeeIds = (
   cache: BirthdayDismissedCacheType | null,
   today: string | null,
   currentUserId: number | undefined
-): number[] =>
-  cache && matchesUserAndDate(cache.userId, cache.date, today, currentUserId)
-    ? cache.dismissedEmployeeIds
-    : [];
+): number[] => {
+  if (!cache || !today || currentUserId === undefined) return [];
+  if (cache.userId !== currentUserId) return [];
+  if (cache.date !== today) return [];
+  return cache.dismissedEmployeeIds;
+};

--- a/frontend/src/community/people/utils/birthdayNotificationCacheUtils.ts
+++ b/frontend/src/community/people/utils/birthdayNotificationCacheUtils.ts
@@ -3,8 +3,14 @@ import {
   removeDataFromLocalStorage,
   setDataToLocalStorage
 } from "~community/common/utils/accessLocalStorage";
-import { BIRTHDAY_NOTIFICATION_VIEW_STATE_CACHE_KEY } from "~community/people/constants/stringConstants";
-import { BirthdayNotificationViewStateType } from "~community/people/types/BirthdayNotificationTypes";
+import {
+  BIRTHDAY_DISMISSED_ENTRIES_CACHE_KEY,
+  BIRTHDAY_NOTIFICATION_VIEW_STATE_CACHE_KEY
+} from "~community/people/constants/stringConstants";
+import {
+  BirthdayDismissedCacheType,
+  BirthdayNotificationViewStateType
+} from "~community/people/types/BirthdayNotificationTypes";
 
 export const readViewedCache = (): BirthdayNotificationViewStateType | null => {
   try {
@@ -37,4 +43,39 @@ export const isViewedToday = (
   if (!cache || !today || currentUserId === undefined) return false;
   if (cache.userId !== currentUserId) return false;
   return cache.lastViewedDate === today;
+};
+
+export const readDismissedCache = (): BirthdayDismissedCacheType | null => {
+  try {
+    const cachedValue = getDataFromLocalStorage(
+      BIRTHDAY_DISMISSED_ENTRIES_CACHE_KEY
+    );
+
+    if (!cachedValue || typeof cachedValue !== "object") return null;
+    if (typeof cachedValue.userId !== "number") return null;
+    if (typeof cachedValue.date !== "string") return null;
+    if (!Array.isArray(cachedValue.dismissedEmployeeIds)) return null;
+
+    return cachedValue as BirthdayDismissedCacheType;
+  } catch {
+    removeDataFromLocalStorage(BIRTHDAY_DISMISSED_ENTRIES_CACHE_KEY);
+    return null;
+  }
+};
+
+export const writeDismissedCache = (
+  cache: BirthdayDismissedCacheType
+): void => {
+  setDataToLocalStorage(BIRTHDAY_DISMISSED_ENTRIES_CACHE_KEY, cache);
+};
+
+export const getDismissedEmployeeIds = (
+  cache: BirthdayDismissedCacheType | null,
+  today: string | null,
+  currentUserId: number | undefined
+): number[] => {
+  if (!cache || !today || currentUserId === undefined) return [];
+  if (cache.userId !== currentUserId) return [];
+  if (cache.date !== today) return [];
+  return cache.dismissedEmployeeIds;
 };

--- a/frontend/src/community/people/utils/birthdayNotificationCacheUtils.ts
+++ b/frontend/src/community/people/utils/birthdayNotificationCacheUtils.ts
@@ -12,22 +12,61 @@ import {
   BirthdayNotificationViewStateType
 } from "~community/people/types/BirthdayNotificationTypes";
 
-export const readViewedCache = (): BirthdayNotificationViewStateType | null => {
+const readCache = <T>(
+  key: string,
+  isValid: (value: unknown) => value is T
+): T | null => {
   try {
-    const cachedValue = getDataFromLocalStorage(
-      BIRTHDAY_NOTIFICATION_VIEW_STATE_CACHE_KEY
-    );
+    const cachedValue = getDataFromLocalStorage(key);
 
-    if (!cachedValue || typeof cachedValue !== "object") return null;
-    if (typeof cachedValue.userId !== "number") return null;
-    if (typeof cachedValue.lastViewedDate !== "string") return null;
+    if (!isValid(cachedValue)) return null;
 
-    return cachedValue as BirthdayNotificationViewStateType;
+    return cachedValue;
   } catch {
-    removeDataFromLocalStorage(BIRTHDAY_NOTIFICATION_VIEW_STATE_CACHE_KEY);
+    removeDataFromLocalStorage(key);
     return null;
   }
 };
+
+const isViewedCacheShape = (
+  value: unknown
+): value is BirthdayNotificationViewStateType => {
+  const cache = value as BirthdayNotificationViewStateType;
+
+  return (
+    !!cache &&
+    typeof cache === "object" &&
+    typeof cache.userId === "number" &&
+    typeof cache.lastViewedDate === "string"
+  );
+};
+
+const isDismissedCacheShape = (
+  value: unknown
+): value is BirthdayDismissedCacheType => {
+  const cache = value as BirthdayDismissedCacheType;
+
+  return (
+    !!cache &&
+    typeof cache === "object" &&
+    typeof cache.userId === "number" &&
+    typeof cache.date === "string" &&
+    Array.isArray(cache.dismissedEmployeeIds)
+  );
+};
+
+const matchesUserAndDate = (
+  cacheUserId: number,
+  cacheDate: string,
+  today: string | null,
+  currentUserId: number | undefined
+): boolean => {
+  if (!today || currentUserId === undefined) return false;
+  return cacheUserId === currentUserId && cacheDate === today;
+};
+
+export const readViewedCache = (): BirthdayNotificationViewStateType | null =>
+  readCache(BIRTHDAY_NOTIFICATION_VIEW_STATE_CACHE_KEY, isViewedCacheShape);
 
 export const writeViewedCache = (
   cache: BirthdayNotificationViewStateType
@@ -39,29 +78,12 @@ export const isViewedToday = (
   cache: BirthdayNotificationViewStateType | null,
   today: string | null,
   currentUserId: number | undefined
-): boolean => {
-  if (!cache || !today || currentUserId === undefined) return false;
-  if (cache.userId !== currentUserId) return false;
-  return cache.lastViewedDate === today;
-};
+): boolean =>
+  !!cache &&
+  matchesUserAndDate(cache.userId, cache.lastViewedDate, today, currentUserId);
 
-export const readDismissedCache = (): BirthdayDismissedCacheType | null => {
-  try {
-    const cachedValue = getDataFromLocalStorage(
-      BIRTHDAY_DISMISSED_ENTRIES_CACHE_KEY
-    );
-
-    if (!cachedValue || typeof cachedValue !== "object") return null;
-    if (typeof cachedValue.userId !== "number") return null;
-    if (typeof cachedValue.date !== "string") return null;
-    if (!Array.isArray(cachedValue.dismissedEmployeeIds)) return null;
-
-    return cachedValue as BirthdayDismissedCacheType;
-  } catch {
-    removeDataFromLocalStorage(BIRTHDAY_DISMISSED_ENTRIES_CACHE_KEY);
-    return null;
-  }
-};
+export const readDismissedCache = (): BirthdayDismissedCacheType | null =>
+  readCache(BIRTHDAY_DISMISSED_ENTRIES_CACHE_KEY, isDismissedCacheShape);
 
 export const writeDismissedCache = (
   cache: BirthdayDismissedCacheType
@@ -69,13 +91,15 @@ export const writeDismissedCache = (
   setDataToLocalStorage(BIRTHDAY_DISMISSED_ENTRIES_CACHE_KEY, cache);
 };
 
+export const clearDismissedCache = (): void => {
+  removeDataFromLocalStorage(BIRTHDAY_DISMISSED_ENTRIES_CACHE_KEY);
+};
+
 export const getDismissedEmployeeIds = (
   cache: BirthdayDismissedCacheType | null,
   today: string | null,
   currentUserId: number | undefined
-): number[] => {
-  if (!cache || !today || currentUserId === undefined) return [];
-  if (cache.userId !== currentUserId) return [];
-  if (cache.date !== today) return [];
-  return cache.dismissedEmployeeIds;
-};
+): number[] =>
+  cache && matchesUserAndDate(cache.userId, cache.date, today, currentUserId)
+    ? cache.dismissedEmployeeIds
+    : [];


### PR DESCRIPTION
Fixes birthday notification modals reappearing after a page refresh once already dismissed, by persisting dismissed employee IDs to localStorage (scoped by user + date) and filtering them out when the queue rebuilds on mount.