### PR TITLE
Fix/2947: Leave policy - mandatory fields missing red asterisk in create policy flow

### DIFF
--- a/frontend/src/community/leave/components/organisms/LeavePolicyWizard/BasicInfoStep.tsx
+++ b/frontend/src/community/leave/components/organisms/LeavePolicyWizard/BasicInfoStep.tsx
@@ -58,6 +58,7 @@ const BasicInfoStep: FC<Props> = ({ formData, onChange, errors, touched }) => {
             label={translateText(["basicInfo", "policyNameLabel"])}
             name="policyName"
             type="text"
+            required
             value={formData.policyName}
             placeholder={translateText(["basicInfo", "policyNamePlaceholder"])}
             state={policyNameError ? "error" : "default"}
@@ -71,6 +72,7 @@ const BasicInfoStep: FC<Props> = ({ formData, onChange, errors, touched }) => {
             <Dropdown
               id="leave-policy-leave-type"
               label={translateText(["basicInfo", "leaveTypeLabel"])}
+              required
               value={formData.leaveType}
               placeholder={translateText(["basicInfo", "leaveTypePlaceholder"])}
               options={leaveTypeOptions}


### PR DESCRIPTION
…eave Policy Wizard

## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/[id]) 

### Summary

-

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
