### PR TITLE
Fix/3010: Leave Policy - Duplicate policy name error shows as a toast instead of an inline field error

### DIFF
--- a/frontend/src/community/leave/components/organisms/LeavePolicyWizard/LeavePolicyWizard.tsx
+++ b/frontend/src/community/leave/components/organisms/LeavePolicyWizard/LeavePolicyWizard.tsx
@@ -6,7 +6,7 @@ import {
   IconButton
 } from "@rootcodelabs/skapp-ui";
 import { AxiosError } from "axios";
-import { useFormik } from "formik";
+import { FormikProps, useFormik } from "formik";
 import { useRouter } from "next/router";
 import { FC, useRef, useState } from "react";
 
@@ -24,6 +24,7 @@ import {
 } from "~community/leave/types/LeavePolicyTypes";
 import {
   getLeavePolicyErrorToastKeys,
+  isDuplicatePolicyNameError,
   mapLeavePolicyFormToPayload
 } from "~community/leave/utils/leavePolicy/leavePolicyUtils";
 import { leavePolicyWizardValidation } from "~community/leave/utils/validations";
@@ -73,6 +74,8 @@ const LeavePolicyWizard: FC<Props> = ({ policyType }) => {
 
   const submittedNameRef = useRef<string>("");
 
+  const formikRef = useRef<FormikProps<LeavePolicyFormData> | null>(null);
+
   const steps = [
     translateText(["steps", "basicInfo"]),
     translateText(["steps", "entitlementSetup"]),
@@ -100,6 +103,16 @@ const LeavePolicyWizard: FC<Props> = ({ policyType }) => {
   };
 
   const handleError = (error: AxiosError): void => {
+    if (isDuplicatePolicyNameError(error)) {
+      formikRef.current?.setFieldTouched("policyName", true, false);
+      formikRef.current?.setFieldError(
+        "policyName",
+        translateText(["duplicateToastDescription"])
+      );
+      setActiveStep(LeavePolicyWizardSteps.BASIC_INFO);
+      return;
+    }
+
     const { title, description } = getLeavePolicyErrorToastKeys(error);
 
     setToastMessage({
@@ -124,6 +137,8 @@ const LeavePolicyWizard: FC<Props> = ({ policyType }) => {
       addLeavePolicy(mapLeavePolicyFormToPayload(values));
     }
   });
+
+  formikRef.current = formik;
 
   const handleFieldsChange = (values: Partial<LeavePolicyFormData>): void => {
     formik.setValues({ ...formik.values, ...values });

--- a/frontend/src/community/leave/utils/leavePolicy/leavePolicyUtils.ts
+++ b/frontend/src/community/leave/utils/leavePolicy/leavePolicyUtils.ts
@@ -19,6 +19,10 @@ interface LeavePolicyErrorToastKeys {
   description: string;
 }
 
+export const isDuplicatePolicyNameError = (error: AxiosError): boolean =>
+  (error?.response?.data as LeavePolicyErrorData | undefined)?.results?.[0]
+    ?.messageKey === LEAVE_ERROR_LEAVE_POLICY_ALREADY_EXISTS;
+
 export const getLeavePolicyErrorToastKeys = (
   error: AxiosError
 ): LeavePolicyErrorToastKeys => {


### PR DESCRIPTION
## PR checklist

### TaskId: (https://github.com/SkappHQ/skapp/issues/[id]) 

### Summary

-

### How to test

1.

### Project Checklist

- [ ] Changes build without any errors
- [ ] Have written adequate test cases
- [ ] Done developer testing in
  - [ ] Chrome
  - [ ] Firefox
  - [ ] Safari
- [ ] Code is formatted with `npm run format`
- [ ] Code is linted with `npm run check-lint`
- [ ] No unnecessary comments left in code
- [ ] Made corresponding changes to the documentation

#### Other

- [ ] New atomic components added
- [ ] New molecules added
- [ ] New pages(routes) added
- [ ] New dependencies installed

### PR Checklist

- [ ] Pull request is raised from the correct source branch
- [ ] Pull request is raised to the correct destination branch
- [ ] Pull request is raised with correct title
- [ ] Pull request is self reviewed
- [ ] Pull request is self assigned
- [ ] Suitable pull request status labels are added (`ready-for-code-review`)

### Additional Information
-
