### PR TITLE
[Fix] My Leave Requests inherits page size and date filter from All Leave Requests

### DIFF
--- a/frontend/src/community/attendance/components/molecules/AttendanceModals/AddEditTimeEntry/AddEditTimeEntry.tsx
+++ b/frontend/src/community/attendance/components/molecules/AttendanceModals/AddEditTimeEntry/AddEditTimeEntry.tsx
@@ -47,8 +47,8 @@ import {
 } from "~community/common/utils/dateTimeUtils";
 import { useDefaultCapacity } from "~community/configurations/api/timeConfigurationApi";
 import { useGetEmployeeLeaveRequests } from "~community/leave/api/MyRequestApi";
+import { MY_LEAVE_REQUESTS_PER_PAGE } from "~community/leave/constants/stringConstants";
 import { LeaveStatusEnums } from "~community/leave/enums/MyRequestEnums";
-import { useLeaveStore } from "~community/leave/store/store";
 import { useGetAllHolidaysInfinite } from "~community/people/api/HolidayApi";
 
 import styles from "./styles";
@@ -75,16 +75,10 @@ const AddEditTimeEntry = ({ setFromDateTime, setToDateTime }: Props) => {
     currentYear.toString()
   );
 
-  const { data: leaveRequests } = useGetEmployeeLeaveRequests();
-
-  const { setLeaveRequestParams } = useLeaveStore((state) => state);
-
-  useEffect(() => {
-    setLeaveRequestParams("status", [
-      LeaveStatusEnums.APPROVED,
-      LeaveStatusEnums.PENDING
-    ]);
-  }, []);
+  const { data: leaveRequests } = useGetEmployeeLeaveRequests({
+    status: `${LeaveStatusEnums.APPROVED},${LeaveStatusEnums.PENDING}`,
+    size: MY_LEAVE_REQUESTS_PER_PAGE
+  });
 
   const {
     selectedDailyRecord,

--- a/frontend/src/community/leave/api/MyRequestApi.ts
+++ b/frontend/src/community/leave/api/MyRequestApi.ts
@@ -23,12 +23,12 @@ import {
 import { LeaveEntitlementBalanceType } from "~community/leave/types/LeaveEntitlementTypes";
 import {
   LeaveRequestPayloadType,
+  MyLeaveRequestParamsType,
   MyLeaveRequestPayloadType,
   ResourceAvailabilityParamTypes,
   ResourceAvailabilityPayload
 } from "~community/leave/types/MyRequests";
 
-import { useLeaveStore } from "../store/store";
 import { LeaveRequestItemsType } from "../types/LeaveRequestTypes";
 
 export const useGetLeaveAllocation = (selectedYear: string, enabled = true) => {
@@ -150,9 +150,9 @@ export const useApplyLeave = (
   });
 };
 
-export const useGetEmployeeLeaveRequests = () => {
-  const params = useLeaveStore((state) => state.leaveRequestParams);
-
+export const useGetEmployeeLeaveRequests = (
+  params: MyLeaveRequestParamsType
+) => {
   return useQuery({
     queryKey: [leaveQueryKeys.EMPLOYEE_LEAVE_REQUESTS, params],
     queryFn: async () => {

--- a/frontend/src/community/leave/components/molecules/LeaveRequests/LeaveRequests.tsx
+++ b/frontend/src/community/leave/components/molecules/LeaveRequests/LeaveRequests.tsx
@@ -15,6 +15,7 @@ import {
   useGetEmployeeLeaveRequests
 } from "~community/leave/api/MyRequestApi";
 import MyLeaveRequestFilterBody from "~community/leave/components/molecules/MyLeaveRequestFilterBody/MyLeaveRequestFilterBody";
+import { MY_LEAVE_REQUESTS_PER_PAGE } from "~community/leave/constants/stringConstants";
 import { useLeaveStore } from "~community/leave/store/store";
 import { LeaveRequestDataType } from "~community/leave/types/EmployeeLeaveRequestTypes";
 import { generateMyLeaveRequestAriaLabel } from "~community/leave/utils/accessibilityUtils";
@@ -26,9 +27,8 @@ import styles from "./styles";
 const LeaveRequests: FC = () => {
   const classes = styles();
 
-  const currentPage = useLeaveStore((state) => state.leaveRequestParams.page);
-  const leaveRequestSort = useLeaveStore(
-    (state) => state.leaveRequestParams.sortKey
+  const { status, leaveType, page, sortKey } = useLeaveStore(
+    (state) => state.leaveRequestParams
   );
   const {
     setPagination,
@@ -40,7 +40,13 @@ const LeaveRequests: FC = () => {
     leaveRequestsFilter
   } = useLeaveStore((state) => state);
 
-  const { data: leaveRequests, isLoading } = useGetEmployeeLeaveRequests();
+  const { data: leaveRequests, isLoading } = useGetEmployeeLeaveRequests({
+    status,
+    leaveType,
+    page,
+    sortKey,
+    size: MY_LEAVE_REQUESTS_PER_PAGE
+  });
 
   const {
     refetch,
@@ -188,14 +194,14 @@ const LeaveRequests: FC = () => {
       onRowClick={handleRowClick}
       pagination={{
         totalPages: leaveRequests?.totalPages,
-        currentPage: currentPage as number,
+        currentPage: page,
         onPageChange: setPagination
       }}
       toolbar={{
         dropdown: {
           id: "my-leave-requests-sort",
           options: sortOptions,
-          value: leaveRequestSort,
+          value: sortKey,
           onChange: handleSortChange,
           renderSelectedValue: renderSelectedSortValue,
           width: "auto",

--- a/frontend/src/community/leave/components/molecules/ManagerLeaveRequests/ManagerLeaveRequest.tsx
+++ b/frontend/src/community/leave/components/molecules/ManagerLeaveRequests/ManagerLeaveRequest.tsx
@@ -85,9 +85,7 @@ const ManagerLeaveRequest: FC<Props> = ({
     leaveRequestsFilter: state.leaveRequestsFilter
   }));
 
-  const currentPage: number = useLeaveStore(
-    (state) => state.leaveRequestParams.page
-  ) as number;
+  const currentPage = useLeaveStore((state) => state.leaveRequestParams.page);
 
   const leaveRequestSort = leaveRequestParams.sortKey;
 
@@ -238,17 +236,10 @@ const ManagerLeaveRequest: FC<Props> = ({
   useEffect(() => {
     if (employeeLeaveRequests?.length === 0 && totalPages === 0) {
       if (currentPage !== 0) {
-        setLeaveRequestParams("page", (currentPage - 1).toString());
         setPagination(currentPage - 1);
       }
     }
-  }, [
-    currentPage,
-    employeeLeaveRequests?.length,
-    setLeaveRequestParams,
-    setPagination,
-    totalPages
-  ]);
+  }, [currentPage, employeeLeaveRequests?.length, setPagination, totalPages]);
 
   useEffect(() => {
     if (getLeaveByIdSuccess && getLeaveByIdData) {

--- a/frontend/src/community/leave/constants/stringConstants.ts
+++ b/frontend/src/community/leave/constants/stringConstants.ts
@@ -8,6 +8,8 @@ export const POLICY_LEAVE_REQUESTS_PER_PAGE = 10;
 
 export const MANAGER_LEAVE_REQUESTS_PER_PAGE = 6;
 
+export const MY_LEAVE_REQUESTS_PER_PAGE = 4;
+
 export const LEAVE_REQUESTS_SKELETON_ROWS = 5;
 
 export const MAX_ALLOWED_UPLOADS = 5;

--- a/frontend/src/community/leave/types/MyRequests.ts
+++ b/frontend/src/community/leave/types/MyRequests.ts
@@ -64,6 +64,14 @@ export interface ResourceAvailabilityPayload {
   holidays: HolidayType[];
 }
 
+export interface MyLeaveRequestParamsType {
+  status?: string;
+  leaveType?: string;
+  page?: number;
+  sortKey?: string;
+  size: number;
+}
+
 export interface MyLeaveRequestPayloadType {
   leaveRequestId: number;
   startDate: string;

--- a/frontend/src/community/leave/types/StoreTypes.ts
+++ b/frontend/src/community/leave/types/StoreTypes.ts
@@ -205,7 +205,7 @@ export interface LeaveStore extends actionsTypes {
     startDate?: string;
     endDate?: string;
     sortKey?: string;
-    page?: number | string;
+    page: number;
     size?: string;
     managerType?: string[];
   };


### PR DESCRIPTION
## Summary

The My Leave Requests table showed a different row count and a different set of requests each time it was revisited, without the user ever leaving the page. It read the whole shared `leaveRequestParams` store object, which the All Leave Requests screen writes `size`, `startDate` and `endDate` into on mount. Returning to My Leave Requests therefore ran the query with a page size of 6 and a current-year date window it never asked for. The query hook now takes its params as an argument, so each caller declares exactly what it needs.

## Changes in this repo (`SkappHQ/skapp`)

- `useGetEmployeeLeaveRequests` takes a `MyLeaveRequestParamsType` argument instead of reading `leaveRequestParams` out of the store. `MyRequestApi.ts` no longer imports `useLeaveStore` at all.
- `LeaveRequests` (My Leave Requests) passes only `status`, `leaveType`, `page`, `sortKey` and its own `MY_LEAVE_REQUESTS_PER_PAGE`. It never asks for `startDate`/`endDate`, so the date window cannot reach it.
- `AddEditTimeEntry` (timesheet modal) passes its own status filter instead of mutating shared store state on mount to steer the query. Removes a `useEffect`, a `setLeaveRequestParams` call and the `useLeaveStore` import — and one more writer to the shared object.
- `leaveRequestParams.page` typed as a required `number` instead of `number | string`, removing an `as number` cast at both read sites. The only string writer set `page` immediately before `setPagination` overwrote it with a number, so that redundant write is gone too.
- New `MY_LEAVE_REQUESTS_PER_PAGE = 4` constant, alongside the existing `MANAGER_LEAVE_REQUESTS_PER_PAGE`. Value matches what the store initialised to, so a fresh load is unchanged.

## Reproduction

From the reported recording, URL bar reads `/leave/my-requests` in every frame — the user never navigates away:

| Time | Same table |
|------|-----------|
| 0:04 | page 3 of **7**, **4 rows**/page |
| 0:13 | page 7 of 7, last row `28th Oct 2025` |
| 0:25 | page 2 of **2**, still 4 rows |
| 0:34 | page 1 of 2, **6 rows**, all rows 2026 |

Two independent bleeds, landing as separate store updates: the page count collapsing from 7 to 2 (and the 2025 request disappearing) is `startDate`/`endDate`; 4 rows becoming 6 is `size`.

## Architecture / flow

```mermaid
flowchart TB
    subgraph before["Before — one shared object"]
        M1[All Leave Requests<br/>mount effect]
        S1[("leaveRequestParams<br/>status, leaveType, page, sortKey<br/>size, startDate, endDate")]
        L1[My Leave Requests]
        M1 -->|"writes size=6<br/>startDate, endDate"| S1
        S1 -->|"reads ALL fields"| L1
        L1 -.->|"GET /leave?size=6<br/>&startDate&endDate"| X[wrong rows]
    end

    subgraph after["After — caller declares its params"]
        S2[("leaveRequestParams")]
        L2[My Leave Requests]
        T2[Timesheet modal]
        H2["useGetEmployeeLeaveRequests(params)"]
        S2 -->|"reads status, leaveType,<br/>page, sortKey only"| L2
        L2 -->|"+ own page size"| H2
        T2 -->|"own status filter"| H2
        H2 --> Y[GET /leave]
    end
```

## Exclusions — deliberately NOT in this PR

- **Backend query fixes.** The `findAllRequestsByEmployee` pagination sort has no unique tiebreaker (tied rows can reshuffle between pages on MySQL) and the date predicate is `start BETWEEN a AND b OR end BETWEEN a AND b`, which drops a leave spanning the whole window. Both are real but neither causes this bug. Held for a separate backend PR.
- **`status`, `leaveType` and `page` are still shared** with All Leave Requests, so applying a status filter there still affects My Leave Requests on return. Not what this ticket or the recording shows; separating the remaining state is a larger refactor.
- **`UserLeaveHistory` writes `size`/`startDate`/`endDate`** into the same shared object, but its own table never reads them (`useGetEmployeeLeaveHistory` takes explicit args). Those writes are dead for that screen and now only affect All Leave Requests.
- **The timesheet modal reuses `MY_LEAVE_REQUESTS_PER_PAGE`** for its date-picker query. It only ever received one page before (size 4 or 6 depending on navigation history), so this is no worse and is now deterministic — but it arguably wants all active leaves unpaged. Left alone to keep this PR to the reported bug.

## Ignored — handled elsewhere / at deployment

- **Submodule hash / pointer bumps** are intentionally excluded. `backend/src/main/java/com/skapp/enterprise` and `frontend/src/enterprise` moved when the branch was fast-forwarded onto latest `develop`; those gitlinks are left unstaged and out of both commits. Gitlink updates happen at deployment time, not in feature PRs.

## Testing

| Check | Ran? | Result |
|-------|------|--------|
| **e2e (Playwright)** | **yes** | **pass on this branch, fails on `develop`** — see below |
| tsc (`--noEmit`) | yes | pass — 0 new errors, diffed by `file(line,col): TScode` against a stashed baseline on the same `develop` (656 pre-existing both sides) |
| eslint | yes | pass — 0 errors; 8 pre-existing `exhaustive-deps` warnings on effects this PR does not touch |
| prettier | yes | pass — changed files only |
| `next build` | yes | pass — compiled successfully |
| Unit tests | n/a | no jest specs cover the changed files, and per the repo rules FE component tests are not added |
| Formatter / tsc-lint (BE only) | n/a | frontend-only change |

### e2e regression guard

Added `tests/leave/my-requests-consistency.spec.ts` to the e2e suite (`leave` feature). It seeds eight PENDING requests through the suite's tenant-scoped DB helper — six in the current year, two in the previous one — then walks My Leave Requests → All Leave Requests → My Leave Requests **via the sidebar**, and asserts the row count, the pager and the page-size/date-window parameters are unchanged.

The navigation has to be an in-app route change. An earlier version used `page.goto`, which reloads the app, rebuilds the zustand store from its defaults and made the test pass against the unfixed code — a false green. The previous-year rows matter for the same reason: without them a current-year window changes nothing visible.

Run against both branches, backend and data identical:

| | `develop` (unfixed) | this branch |
|---|---|---|
| rows, 1st visit → 2nd | 5 → **7** | 5 → 5 |
| pager, 1st → 2nd | `1 2 3` → **`1 2`** | `1 2 3` → `1 2 3` |
| `size` | 4 → **6** | 4 → 4 |
| `startDate` / `endDate` | none → **2026-01-01 / 2026-12-31** | none → none |
| result | ✘ fails | ✓ passes |

That reproduces the reported recording: rows growing, the page count collapsing, and the previous-year request dropping out of its own list.

### One residual leak this surfaced

The run also shows `status=PENDING` becoming `status=PENDING,` after the trip to All Requests — a trailing comma from `setLeaveRequestParams`' array serialisation. It is the `status`-still-shared case listed under Exclusions above, does not change the result set, and is out of scope here. The spec logs the full query string but scopes its assertion to the parameters this PR owns, so the leak is recorded rather than hidden.
