### PR TITLE
[Fix] Stabilise My Leave Requests pagination and date range filtering

### DIFF
--- a/backend/src/main/java/com/skapp/community/leaveplanner/repository/impl/LeaveRequestRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/leaveplanner/repository/impl/LeaveRequestRepositoryImpl.java
@@ -56,6 +56,7 @@ import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Order;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Subquery;
@@ -771,7 +772,7 @@ public class LeaveRequestRepositoryImpl implements LeaveRequestRepository {
 		Root<LeaveRequest> root = criteriaQuery.from(LeaveRequest.class);
 		buildEmployeeLeavePredicates(criteriaBuilder, root, predicates, employeeId, leaveRequestFilterDto);
 		criteriaQuery.where(predicates.toArray(new Predicate[0]));
-		criteriaQuery.orderBy(QueryUtils.toOrders(page.getSort(), root, criteriaBuilder));
+		criteriaQuery.orderBy(buildStableOrders(criteriaBuilder, root, page));
 
 		TypedQuery<LeaveRequest> query = entityManager.createQuery(criteriaQuery);
 		if (page.isPaged()) {
@@ -793,6 +794,12 @@ public class LeaveRequestRepositoryImpl implements LeaveRequestRepository {
 		return new PageImpl<>(results, page, results.size());
 	}
 
+	private List<Order> buildStableOrders(CriteriaBuilder criteriaBuilder, Root<LeaveRequest> root, Pageable page) {
+		List<Order> orders = new ArrayList<>(QueryUtils.toOrders(page.getSort(), root, criteriaBuilder));
+		orders.add(criteriaBuilder.desc(root.get(LeaveRequest_.leaveRequestId)));
+		return orders;
+	}
+
 	private void buildEmployeeLeavePredicates(CriteriaBuilder criteriaBuilder, Root<LeaveRequest> root,
 			List<Predicate> predicates, Long employeeId, LeaveRequestFilterDto leaveRequestFilterDto) {
 		predicates.add(criteriaBuilder.equal(root.get(LeaveRequest_.EMPLOYEE).get(Employee_.EMPLOYEE_ID), employeeId));
@@ -808,12 +815,12 @@ public class LeaveRequestRepositoryImpl implements LeaveRequestRepository {
 		}
 
 		if (leaveRequestFilterDto.getStartDate() != null && leaveRequestFilterDto.getEndDate() != null) {
-			Predicate dateBetween = criteriaBuilder.or(
-					criteriaBuilder.between(root.get(LeaveRequest_.START_DATE), leaveRequestFilterDto.getStartDate(),
+			Predicate dateOverlap = criteriaBuilder.and(
+					criteriaBuilder.lessThanOrEqualTo(root.get(LeaveRequest_.startDate),
 							leaveRequestFilterDto.getEndDate()),
-					criteriaBuilder.between(root.get(LeaveRequest_.END_DATE), leaveRequestFilterDto.getStartDate(),
-							leaveRequestFilterDto.getEndDate()));
-			predicates.add(dateBetween);
+					criteriaBuilder.greaterThanOrEqualTo(root.get(LeaveRequest_.endDate),
+							leaveRequestFilterDto.getStartDate()));
+			predicates.add(dateOverlap);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Two correctness problems in the query behind **My Leave Requests** (`GET /leave` → `LeaveRequestRepositoryImpl.findAllRequestsByEmployee`): pagination has no deterministic ordering, and the date filter silently drops leaves that span the whole requested range. Both are longstanding and independent of any UI change.

## Changes in this repo (`SkappHQ/skapp`)

- **Deterministic paging.** The query ordered only by the requested sort column — `startDate` or `createdDate` (`LeaveRequestSort`). Neither is unique, so rows that tie have no defined order and MySQL is free to return a different slice for the same `LIMIT/OFFSET` across calls. `leaveRequestId` is now appended as a final ordering, extracted into `buildStableOrders`.
- **Correct range overlap.** The filter matched `startDate BETWEEN range OR endDate BETWEEN range`, which misses a leave that starts *before* the range and ends *after* it — a long leave spanning the window disappears from its own date filter. Replaced with the standard overlap test already used by the sibling queries in this class (`setDateRangeFiltration`): `startDate <= rangeEnd AND endDate >= rangeStart`.

## Impact

```mermaid
flowchart TB
    subgraph sort["Ordering — ties had no tiebreaker"]
        A["ORDER BY startDate DESC<br/>LIMIT 4 OFFSET 4"] --> B{"rows tie on startDate"}
        B -->|"call 1"| C["rows A, B, C, D"]
        B -->|"call 2"| D["rows A, C, B, E"]
        C -.->|"same query,<br/>different page"| D
        E["ORDER BY startDate DESC,<br/>leaveRequestId DESC"] --> F["stable slice"]
    end

    subgraph range["Range — spanning leave was dropped"]
        G["filter: Mar 1 – Mar 31"]
        H["leave: Feb 20 – Apr 10"]
        G --> I{"start BETWEEN or<br/>end BETWEEN?"}
        I -->|"neither is inside"| J["excluded"]
        G --> K{"start <= Mar 31<br/>AND end >= Mar 1?"}
        K -->|"yes"| L["included"]
    end
```

## Exclusions — deliberately NOT in this PR

- **The frontend fix for the reported record-count bug** is separate. That bug was shared client state, not this query; the two are unrelated and are kept apart so each can be reviewed on its own.
- **Only `findAllRequestsByEmployee` is touched.** `findAllLeaveRequests`, `findAllRequestAssignedToManager` and `getLeaveRequestHistoryByTeam` have the same missing tiebreaker, but they are not what this change is about and widening it would make the diff harder to reason about. Worth a follow-up.
- The metamodel `String` constants (`LeaveRequest_.START_DATE`) already used in this method are left as-is except on the lines being changed, which now use the typed attributes (`LeaveRequest_.startDate`) so the comparisons stay type-checked.

## Ignored — handled elsewhere / at deployment

- **Submodule hash / pointer bumps** are intentionally excluded. Gitlink updates are done at **deployment time**, not in feature PRs.

## Testing

| Check | Ran? | Result |
|-------|------|--------|
| Unit / integration tests | yes | **pass** — `LeaveControllerIntegrationTest` 16/16 (9 of them `Get Current User Leave Requests`, covering date-range, pagination, sorting and all-filters-combined — the exact paths changed) |
| Formatter (checkstyle) | yes | pass — `mvn checkstyle:check` BUILD SUCCESS |
| Compile | yes | pass — `mvn compile` BUILD SUCCESS on latest `develop` |
| tsc + lint | n/a | backend-only change |
| e2e (Playwright) | no | suite has no leave specs; the running local mirror currently fronts another workspace's dev server, so a run would not have exercised this branch |

Note: an `okr_company_objective` H2 DDL warning (`year` is reserved) appears during the test run. It is present on clean `develop`, unrelated to this change, and non-fatal — the suite passes.
