### PR TITLE
fix: birthday modal name display and overflow/scroll for long names

### DIFF
--- a/frontend/src/community/people/components/molecules/BirthdayModals/BirthdayModalShell.tsx
+++ b/frontend/src/community/people/components/molecules/BirthdayModals/BirthdayModalShell.tsx
@@ -33,7 +33,7 @@ const BirthdayModalShell: FC<Props> = ({
     <LargeModal
       id={id}
       isOpen
-      className="relative h-[603px] max-h-[85vh] w-[1107px] max-w-[92vw] overflow-hidden rounded-l-[42.69px] rounded-r-[24px] shadow-[0_20px_40px_rgba(0,0,0,0.15)]"
+      className="relative h-auto min-h-[603px] max-h-[85vh] w-[1107px] max-w-[92vw] overflow-hidden rounded-l-[42.69px] rounded-r-[24px] shadow-[0_20px_40px_rgba(0,0,0,0.15)] [&_.overflow-y-auto]:overflow-visible"
       imagePosition="left"
       backdropVariant="dark"
       onClose={onDismiss}
@@ -45,7 +45,7 @@ const BirthdayModalShell: FC<Props> = ({
         </div>
       }
       content={
-        <div className="flex h-[555px] flex-col items-center justify-center gap-4 text-center">
+        <div className="flex min-h-[555px] flex-col items-center justify-center gap-4 text-center">
           {total > 1 && (
             <p className="sr-only">
               {translateAria(["notificationPosition"], {
@@ -66,7 +66,7 @@ const BirthdayModalShell: FC<Props> = ({
                 : employee.firstName
             })}
           />
-          <h2 className="h1 leading-6 tracking-[0.07px] wrap-break-word text-black">
+          <h2 className="h1 line-clamp-2 w-full pr-1 leading-tight tracking-[0.07px] break-words text-black">
             {heading}
           </h2>
           <p className="body2 max-w-104 leading-normal text-secondary-text">

--- a/frontend/src/community/people/components/molecules/BirthdayModals/BirthdayModalShell.tsx
+++ b/frontend/src/community/people/components/molecules/BirthdayModals/BirthdayModalShell.tsx
@@ -33,7 +33,7 @@ const BirthdayModalShell: FC<Props> = ({
     <LargeModal
       id={id}
       isOpen
-      className="relative h-auto min-h-[603px] max-h-[85vh] w-[1107px] max-w-[92vw] overflow-hidden rounded-l-[42.69px] rounded-r-[24px] shadow-[0_20px_40px_rgba(0,0,0,0.15)] [&_.overflow-y-auto]:overflow-visible"
+      className="relative h-[603px] max-h-[85vh] w-[1107px] max-w-[92vw] overflow-hidden rounded-l-[42.69px] rounded-r-[24px] shadow-[0_20px_40px_rgba(0,0,0,0.15)]"
       imagePosition="left"
       backdropVariant="dark"
       onClose={onDismiss}
@@ -45,7 +45,7 @@ const BirthdayModalShell: FC<Props> = ({
         </div>
       }
       content={
-        <div className="flex min-h-[555px] flex-col items-center justify-center gap-4 text-center">
+        <div className="flex h-[555px] flex-col items-center justify-center gap-4 text-center">
           {total > 1 && (
             <p className="sr-only">
               {translateAria(["notificationPosition"], {
@@ -66,7 +66,7 @@ const BirthdayModalShell: FC<Props> = ({
                 : employee.firstName
             })}
           />
-          <h2 className="h1 line-clamp-2 w-full pr-1 leading-tight tracking-[0.07px] break-words text-black">
+          <h2 className="h1 line-clamp-2 w-full px-1 leading-tight tracking-[0.07px] wrap-break-word text-black">
             {heading}
           </h2>
           <p className="body2 max-w-104 leading-normal text-secondary-text">

--- a/frontend/src/community/people/components/molecules/BirthdayModals/SelfBirthdayModal.tsx
+++ b/frontend/src/community/people/components/molecules/BirthdayModals/SelfBirthdayModal.tsx
@@ -1,7 +1,6 @@
 import { FC } from "react";
 
 import { useTranslator } from "~community/common/hooks/useTranslator";
-import { concatStrings } from "~community/common/utils/commonUtil";
 import BirthdayModalShell from "~community/people/components/molecules/BirthdayModals/BirthdayModalShell";
 import { EmployeeBirthdayType } from "~community/people/types/BirthdayNotificationTypes";
 
@@ -27,9 +26,7 @@ const SelfBirthdayModal: FC<Props> = ({
       id={MODAL_ID}
       employee={employee}
       heading={translateText(["self", "heading"], {
-        name: employee.lastName
-          ? concatStrings([employee.firstName, employee.lastName])
-          : employee.firstName
+        name: employee.firstName
       })}
       body={translateText(["self", "body"])}
       position={position}


### PR DESCRIPTION
Fixes the Birthday Notification modal so the self view shows only the first name instead of the full name, and long names now wrap and truncate cleanly instead of overflowing and forcing the modal to scroll.