### PR TITLE
fix: tooltip not announced by screen readers

### DIFF
--- a/frontend/src/community/common/components/atoms/Tooltip/Tooltip.tsx
+++ b/frontend/src/community/common/components/atoms/Tooltip/Tooltip.tsx
@@ -95,8 +95,8 @@ const Tooltip: FC<Props> = ({
       title={title}
       TransitionComponent={Fade}
       PopperProps={PopperProps}
-      {...(ariaLabel ? { "aria-label": ariaLabel } : {})}
-      {...(ariaDescription ? { "aria-description": ariaDescription } : {})}
+      ariaLabel={ariaLabel ?? ""}
+      aria-description={ariaDescription ?? ""}
       customstyles={{
         tooltip: {
           maxWidth: maxWidth,

--- a/frontend/src/community/common/components/atoms/Tooltip/Tooltip.tsx
+++ b/frontend/src/community/common/components/atoms/Tooltip/Tooltip.tsx
@@ -95,8 +95,8 @@ const Tooltip: FC<Props> = ({
       title={title}
       TransitionComponent={Fade}
       PopperProps={PopperProps}
-      aria-label={ariaLabel ?? ""}
-      aria-description={ariaDescription ?? ""}
+      {...(ariaLabel ? { "aria-label": ariaLabel } : {})}
+      {...(ariaDescription ? { "aria-description": ariaDescription } : {})}
       customstyles={{
         tooltip: {
           maxWidth: maxWidth,
@@ -131,6 +131,7 @@ const Tooltip: FC<Props> = ({
                   ? theme.palette.error.contrastText
                   : iconColor
             }
+            svgProps={{ "aria-hidden": true, focusable: false }}
           />
         )}
       </span>

--- a/frontend/src/community/common/components/molecules/InputDate/InputDate.tsx
+++ b/frontend/src/community/common/components/molecules/InputDate/InputDate.tsx
@@ -308,7 +308,7 @@ const InputDate: FC<Props> = ({
             id="emoji-field"
             title={tooltip}
             isDisabled={disabled}
-            aria-label={`${lowerCaseLabel} ${translateAria(["ariaLabel"])}`}
+            ariaLabel={`${lowerCaseLabel} ${translateAria(["ariaLabel"])}`}
           />
         )}
       </Stack>


### PR DESCRIPTION
Fixed the shared Tooltip component announcing blank instead of its actual text to screen readers 