### PR TITLE
fix: exclude pending employees from birthday notification modal

### DIFF
--- a/backend/src/main/java/com/skapp/community/peopleplanner/repository/impl/EmployeeRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/peopleplanner/repository/impl/EmployeeRepositoryImpl.java
@@ -1681,7 +1681,7 @@ public class EmployeeRepositoryImpl implements EmployeeRepository {
 
 		List<Predicate> predicates = new ArrayList<>();
 		predicates.add(cb.isTrue(userJoin.get(User_.isActive)));
-		predicates.add(cb.equal(root.get(Employee_.accountStatus), AccountStatus.ACTIVE));
+		predicates.add(root.get(Employee_.accountStatus).in(Set.of(AccountStatus.ACTIVE)));
 		predicates.add(PeopleUtil.notGuestEmployeePredicate(cb, roleJoin));
 
 		predicates.add(cb.isNotNull(personalInfoJoin.get(EmployeePersonalInfo_.birthDate)));

--- a/backend/src/main/java/com/skapp/community/peopleplanner/repository/impl/EmployeeRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/peopleplanner/repository/impl/EmployeeRepositoryImpl.java
@@ -1681,7 +1681,7 @@ public class EmployeeRepositoryImpl implements EmployeeRepository {
 
 		List<Predicate> predicates = new ArrayList<>();
 		predicates.add(cb.isTrue(userJoin.get(User_.isActive)));
-		predicates.add(root.get(Employee_.accountStatus).in(Set.of(AccountStatus.ACTIVE)));
+		predicates.add(cb.equal(root.get(Employee_.accountStatus), AccountStatus.ACTIVE));
 		predicates.add(PeopleUtil.notGuestEmployeePredicate(cb, roleJoin));
 
 		predicates.add(cb.isNotNull(personalInfoJoin.get(EmployeePersonalInfo_.birthDate)));

--- a/backend/src/main/java/com/skapp/community/peopleplanner/repository/impl/EmployeeRepositoryImpl.java
+++ b/backend/src/main/java/com/skapp/community/peopleplanner/repository/impl/EmployeeRepositoryImpl.java
@@ -1681,7 +1681,7 @@ public class EmployeeRepositoryImpl implements EmployeeRepository {
 
 		List<Predicate> predicates = new ArrayList<>();
 		predicates.add(cb.isTrue(userJoin.get(User_.isActive)));
-		predicates.add(root.get(Employee_.accountStatus).in(Set.of(AccountStatus.ACTIVE, AccountStatus.PENDING)));
+		predicates.add(cb.equal(root.get(Employee_.accountStatus), AccountStatus.ACTIVE));
 		predicates.add(PeopleUtil.notGuestEmployeePredicate(cb, roleJoin));
 
 		predicates.add(cb.isNotNull(personalInfoJoin.get(EmployeePersonalInfo_.birthDate)));

--- a/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/PeopleBirthdayNotificationControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/PeopleBirthdayNotificationControllerIntegrationTest.java
@@ -276,7 +276,7 @@ class PeopleBirthdayNotificationControllerIntegrationTest {
 		}
 
 		@Test
-		@DisplayName("Get today's birthdays with ORGANIZATION scope - Returns all matching employees, including pending ones, ordered by name")
+		@DisplayName("Get today's birthdays with ORGANIZATION scope - Returns matching employees ordered by name, excluding pending ones")
 		void getTodayBirthdayNotifications_WithOrganizationScope_ReturnsAllMatchingEmployeesOrderedByName()
 				throws Exception {
 			seedConfig(true, true, false);
@@ -291,10 +291,9 @@ class PeopleBirthdayNotificationControllerIntegrationTest {
 			});
 
 			assertSuccessful(performGetTodayRequest(currentUserToken))
-				.andExpect(jsonPath(BIRTHDAYS_COUNT_PATH).value(3))
-				.andExpect(jsonPath(birthdayFieldPath(0, "employeeId")).value(SECOND_OUTSIDER_EMPLOYEE_ID.intValue()))
-				.andExpect(jsonPath(birthdayFieldPath(1, "employeeId")).value(OUTSIDER_EMPLOYEE_ID.intValue()))
-				.andExpect(jsonPath(birthdayFieldPath(2, "employeeId")).value(CURRENT_EMPLOYEE_ID.intValue()));
+				.andExpect(jsonPath(BIRTHDAYS_COUNT_PATH).value(2))
+				.andExpect(jsonPath(birthdayFieldPath(0, "employeeId")).value(OUTSIDER_EMPLOYEE_ID.intValue()))
+				.andExpect(jsonPath(birthdayFieldPath(1, "employeeId")).value(CURRENT_EMPLOYEE_ID.intValue()));
 		}
 
 		@Test

--- a/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/PeopleBirthdayNotificationControllerIntegrationTest.java
+++ b/backend/src/test/java/com/skapp/community/peopleplanner/controller/v1/PeopleBirthdayNotificationControllerIntegrationTest.java
@@ -276,7 +276,7 @@ class PeopleBirthdayNotificationControllerIntegrationTest {
 		}
 
 		@Test
-		@DisplayName("Get today's birthdays with ORGANIZATION scope - Returns matching employees ordered by name, excluding pending ones")
+		@DisplayName("Get today's birthdays with ORGANIZATION scope - Returns all matching employees ordered by name")
 		void getTodayBirthdayNotifications_WithOrganizationScope_ReturnsAllMatchingEmployeesOrderedByName()
 				throws Exception {
 			seedConfig(true, true, false);
@@ -285,15 +285,13 @@ class PeopleBirthdayNotificationControllerIntegrationTest {
 			giveBirthdayOn(SECOND_OUTSIDER_EMPLOYEE_ID, today);
 
 			mutateEmployee(OUTSIDER_EMPLOYEE_ID, employee -> employee.setFirstName("alpha"));
-			mutateEmployee(SECOND_OUTSIDER_EMPLOYEE_ID, employee -> {
-				employee.setFirstName("Alpha");
-				employee.setAccountStatus(AccountStatus.PENDING);
-			});
+			mutateEmployee(SECOND_OUTSIDER_EMPLOYEE_ID, employee -> employee.setFirstName("Alpha"));
 
 			assertSuccessful(performGetTodayRequest(currentUserToken))
-				.andExpect(jsonPath(BIRTHDAYS_COUNT_PATH).value(2))
-				.andExpect(jsonPath(birthdayFieldPath(0, "employeeId")).value(OUTSIDER_EMPLOYEE_ID.intValue()))
-				.andExpect(jsonPath(birthdayFieldPath(1, "employeeId")).value(CURRENT_EMPLOYEE_ID.intValue()));
+				.andExpect(jsonPath(BIRTHDAYS_COUNT_PATH).value(3))
+				.andExpect(jsonPath(birthdayFieldPath(0, "employeeId")).value(SECOND_OUTSIDER_EMPLOYEE_ID.intValue()))
+				.andExpect(jsonPath(birthdayFieldPath(1, "employeeId")).value(OUTSIDER_EMPLOYEE_ID.intValue()))
+				.andExpect(jsonPath(birthdayFieldPath(2, "employeeId")).value(CURRENT_EMPLOYEE_ID.intValue()));
 		}
 
 		@Test


### PR DESCRIPTION
The Birthday Notification modal was incorrectly displaying birthdays for employees still in Pending status, exposing onboarding-in-progress employees to other users before their accounts were fully active. This happened because the repository query backing the notification (findEmployeeBirthdaysOnByViewerAndScope in EmployeeRepositoryImpl) filtered on both ACTIVE and PENDING account statuses instead of ACTIVE alone. This change restricts the status predicate to ACTIVE only, ensuring pending employees are excluded from birthday notifications until their onboarding is completed, matching the expected behavior.