### PR TITLE
fix: fetch original-resolution image for birthday modal profile picture

### DIFF
--- a/frontend/src/community/people/components/molecules/BirthdayModals/BirthdayModalShell.tsx
+++ b/frontend/src/community/people/components/molecules/BirthdayModals/BirthdayModalShell.tsx
@@ -31,7 +31,7 @@ const BirthdayModalShell: FC<Props> = ({
   showConfetti = false
 }) => {
   const translateAria = useTranslator("peopleAria", "birthdayNotifications");
-  const imageUrl = useGetImageUrl(employee.authPic ?? "");
+  const imageUrl = useGetImageUrl(employee.authPic ?? "", true);
   const [isConfettiVisible, setIsConfettiVisible] = useState(showConfetti);
 
   useEffect(() => {


### PR DESCRIPTION
Fixes blurred profile pictures in the birthday celebration modal by fetching the original-resolution S3 image instead of the default thumbnail. The change is scoped to BirthdayModalShell.tsx only (passing isOriginalImage = true to useGetImageUrl), so all other avatars across the app (task rows, deal cards, owner pickers, etc.) are unaffected.